### PR TITLE
Load sinks in a nicer fashion

### DIFF
--- a/message_server/server.py
+++ b/message_server/server.py
@@ -51,22 +51,17 @@ class Server:
             raise ValueError("len(sink_name) must be > 0")
 
         components = sink_name.split(".")
-        assert len(components) != 0
 
-        if len(components) == 1:
-            sink = globals()[sink_name]
-        elif len(components) == 2:
-            module_name = components[0]
-            class_name = components[1]
+        if len(components) < 2:
+            raise ValueError("len(sink_name.split(\".\")) must be >= 2")
 
-            module = __import__(module_name)
-            sink = getattr(module, class_name)
-        else:
-            parent_module = ".".join(components[:-2])
-            module_name = ".".join(components[:-1])
-            class_name = components[-1]
+        if "" in components:
+            raise ValueError("sink_name.split(\".\") contains empty strings")
 
-            module = __import__(module_name, fromlist=[parent_module])
-            sink = getattr(module, class_name)
+        module_name = ".".join(components[:-1])
+        sink = __import__(module_name)
+
+        for i in components[1:]:
+            sink = getattr(sink, i)
 
         return sink

--- a/message_server/tests/test_server.py
+++ b/message_server/tests/test_server.py
@@ -62,6 +62,18 @@ class TestServerSinkLoader:
     def test_refuses_to_load_empty_str(self):
         self.server.load("")
 
+    @raises(ValueError)
+    def test_refuses_to_str_without_enough_components(self):
+        self.server.load("test")
+
+    def test_refuses_to_str_with_empty_components(self):
+        for i in ["asdf.", ".", "asdf..asdf"]:
+            yield self.check_refuses_to_str_with_empty_components, i
+
+    @raises(ValueError)
+    def check_refuses_to_str_with_empty_components(self, name):
+        self.server.load(name)
+
     @raises(AttributeError)
     def test_refuses_to_load_nonexistant_sink_class_by_name(self):
         self.server.load("message_server.tests.test_server.FakeSink99")


### PR DESCRIPTION
Rewrote **import** code to recurse up the list of components, and refuse to load modules with empty components (e.g., asdf..asdf).

**import** returns the topmost module in the "tree"; **import**(module_name, fromlist=[parent_module]) returns the "actual" module you want at the bottom, however, I am not sure if this is the intended use of the fromlist parameter. Therefore, I decided to go for recursing up the returned module using getattr
