### PR TITLE
Added Message and Listener classes

### DIFF
--- a/message_server/__init__.py
+++ b/message_server/__init__.py
@@ -20,5 +20,8 @@ The message server receives messages and pushes each message to one
 or more 'sinks'. 
 """
 
+# These classes are defined in separate files but we want them to be
+# accessible as message_server.Class:
 from sink import Sink
 from server import Server
+from message import Message, Listener

--- a/message_server/message.py
+++ b/message_server/message.py
@@ -1,0 +1,84 @@
+# Copyright 2010 (C) Daniel Richman
+#
+# This file is part of habitat.
+#
+# habitat is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# habitat is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with habitat.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Contains the 'Message' and 'Listener' classes.
+'Message' describes a single message that the server might handle,
+and 'Listener' describes the source from which that message came, by some
+means, though does not hold metadata about that listener, and indeed it is
+not guaranteed (nor even is it expected) that there is one unique object
+per listener.
+
+'Message' has the following initialiser which assigns to the following
+members:
+
+my_message = Message(source, mtype, data)
+where:
+  source is a Listener object
+  mtype is one of the type constants below
+  data is a type-specific data object, which will be validated
+
+The data is then available in
+  message.source
+  message.mtype
+  message.data
+
+Message types:
+  Message.RX_STR - received telemetry string
+  Message.LI_INF - listener information
+  Message.LI_TLM - listener telemetry
+  Message.TELEM  - (parsed) telemetry data
+
+'Listener' has the following initialiser which assigns to the following
+members:
+
+my_listener = Listener(identifier)
+where:
+  identifier is to be implemented
+
+The identifier is then available as Listener.identifier
+"""
+
+class Message:
+    RX_STR, LI_INF, LI_TLM, TELEM = mtypes = range(4)
+
+    def __init__(self, source, mtype, data):
+        # TODO data validation based on type
+
+        if not isinstance(source, Listener):
+            raise TypeError("source must be a Listener object")
+
+        if not isinstance(mtype, int):
+            raise TypeError("mtype must be an int")
+
+        if mtype not in self.mtypes:
+            raise ValueError("mtype is not a valid type")
+
+        self.source = source
+        self.mtype = mtype
+        self.data = data
+
+class Listener:
+    def __init__(self, identifier):
+        self.identifier = identifier
+
+    def __eq__(self, other):
+        return self.identifier == other.identifier
+
+    # compare requests other than __eq__ - we do our best:
+    def __cmp__(self, other):
+        return self.identifier.__cmp__(other.identifier)

--- a/message_server/tests/test_message.py
+++ b/message_server/tests/test_message.py
@@ -1,0 +1,79 @@
+# Copyright 2010 (C) Daniel Richman
+#
+# This file is part of habitat.
+#
+# habitat is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# habitat is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with habitat.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Tests the Message class, found in ../message.py
+""" 
+
+# TODO: when validation is implemented modify these tests
+
+from nose.tools import raises
+from message_server import Message, Listener
+
+class TestMessage:
+    def test_ids_exist_and_are_unique(self):
+        mtypes = set()
+        for i in [ "RX_STR", "LI_INF", "LI_TLM", "TELEM" ]:
+            mtype = getattr(Message, i)
+            assert mtype not in mtypes
+            mtypes.add(mtype)
+
+    def test_initialiser_accepts_and_stores_data(self):
+        source = Listener(1234)
+        mydata = {"asdf": "defg", "hjkl": "yuio"}
+        message = Message(source, Message.RX_STR, mydata)
+        assert message.source == source
+        assert message.mtype == Message.RX_STR
+        assert message.data == mydata
+
+    @raises(TypeError)
+    def test_initialiser_rejects_garbage_source(self):
+        Message("asdf", Message.RX_STR, "asdf")
+
+    @raises(TypeError)
+    def test_initialiser_rejects_null_source(self):
+        Message(None, Message.RX_STR, "asdf")
+
+    @raises(ValueError)
+    def test_initialiser_rejects_invalid_mtype(self):
+        Message(Listener(0), 951, "asdf")
+
+    @raises(TypeError)
+    def test_initialiser_rejects_garbage_mtype(self):
+        Message(Listener(0), "asdf", "asdf")
+
+    def test_initialiser_allows_no_data(self):
+        Message(Listener(0), Message.RX_STR, None)
+
+class TestListener:
+    def test_initialiser_accepts_and_stores_data(self):
+        listener = Listener(910)
+        assert listener.identifier == 910
+        listener = Listener(120)
+        assert listener.identifier == 120
+
+    def test_listener_compares(self):
+        # identifier is still to be implemented, so we'll just try some stuff
+        # NB: "astring".__cmp__() doesn't exist so better hope __eq__ is used
+        for i in [[1,      2, False],
+                  [1,      1, True],
+                  [900,    1, False],
+                  ["asdf", "asdf", True]]:
+            yield self.check_listener_compares, i
+
+    def check_listener_compares(self, i):
+        assert (Listener(i[0]) == Listener(i[1])) == i[2]


### PR DESCRIPTION
The implementation of Listener.identifier is still undecided so I've left it "unimplemented" - sort of. Need to have a chat about this. Perhaps I should also add some metadata like IP address (or class generated by if it was a sink) or smth. 

Maybe Listener.identifier - unqiue
Listener.generator - class "Parser", or "HTTPclient" or whatever (also means we can limit generation of certain messages to certain things; might not want clients firing off TELEM messages (LI_TELEM only))
Listener.generator_info.{ip,hostname,etc.} - arbitrary stuff

Perhaps that could be another story.
