### PR TITLE
Dynamicreloading

### DIFF
--- a/utils/tests/.gitignore
+++ b/utils/tests/.gitignore
@@ -1,1 +1,2 @@
-reloadable.py
+reloadablea.py
+reloadableb.py

--- a/utils/tests/.gitignore
+++ b/utils/tests/.gitignore
@@ -1,0 +1,1 @@
+reloadable.py

--- a/utils/tests/test_dynamicloader.py
+++ b/utils/tests/test_dynamicloader.py
@@ -20,6 +20,8 @@ Tests the Dynamic Loader module, ../dynamicloader.py
 """ 
 
 import sys
+import time
+import os
 import functools
 import datetime
 from utils import dynamicloader
@@ -117,6 +119,74 @@ class TestLoad:
     @raises(ValueError)
     def check_refuses_to_load_str_with_empty_components(self, name):
         dynamicloader.load(name)
+
+    def test_reload_module(self):
+        modulecode_1 = "class asdf:\n    def __init__(self): self.test = 1\n"
+        modulecode_2 = "class asdf:\n    def __init__(self): self.test = 2\n"
+
+        components = __name__.split(".")
+        components[-1:] = ['reloadable', 'asdf']
+        loadable = ".".join(components)
+        assert loadable not in sys.modules
+
+        self.write_reloadable_module(modulecode_1)
+
+        asdf_1a = dynamicloader.load(loadable)
+        asdf_1a_object = asdf_1a()
+        assert asdf_1a_object.test == 1
+
+        self.write_reloadable_module(modulecode_2)
+
+        # Should not cause a reload, should just re-use sys.moudles[loadable]
+        asdf_1b = dynamicloader.load(loadable)
+        assert asdf_1b == asdf_1a
+        asdf_1b_object = asdf_1b()
+        assert asdf_1b_object.test == asdf_1a_object.test == 1
+
+        # This time we want a reload
+        asdf_2a = dynamicloader.load(loadable, force_reload=True)
+        assert asdf_2a != asdf_1b
+        asdf_2a_object = asdf_2a()
+        assert asdf_2a_object.test == 2
+
+        # It should stay reloaded, even without force_reload
+        asdf_2b = dynamicloader.load(loadable)
+        assert asdf_2b == asdf_2a
+        asdf_2b_object = asdf_2a()
+        assert asdf_2b_object.test == asdf_2a_object.test == 2
+
+        # asdf_1b should still be the old module, though in typical use it
+        # would have been discarded by now
+        asdf_1b_object = asdf_1b()
+        assert asdf_1b_object.test == 1
+
+        self.write_reloadable_module(modulecode_1)
+
+        # Finally, we should also be able to reload like this:
+        asdf_1c = dynamicloader.load(asdf_1b)
+        assert asdf_1c != asdf_2a
+        asdf_1c_object = asdf_1c()
+        assert asdf_1c_object.test == 1
+
+    def write_reloadable_module(self, code):
+        filename = os.path.join(os.path.dirname(__file__), "reloadable.py")
+
+        # Even when the builtin reload is called python will read from the
+        # pyc file if the embedded mtime matches that of the py file. That's
+        # typically going to be fine, however, if you load, modify, reload
+        # within one second then the updated module won't be read.
+        # We won't be reloading that fast, but the test will. So hack the 
+        # mtime two seconds into the future every time.
+
+        try:
+            newtime = os.path.getmtime(filename) + 2
+        except OSError:
+            newtime = int(time.time())
+
+        with open(filename, 'w') as f:
+            f.write(code)
+
+        os.utime(filename, (newtime, newtime))
 
 class TestInspectors:
     def test_isclass(self):


### PR DESCRIPTION
dynamicloader can reload modules. Warning: see utils/tests/test_dynamicloader.py write_reloadable_module for info on a potential issue:

```
    # Even when the builtin reload is called python will read from the
    # pyc file if the embedded mtime matches that of the py file. That's
    # typically going to be fine, however, if you load, modify, reload
    # within one second then the updated module won't be read.
    # We won't be reloading that fast, but the test will. So hack the 
    # mtime two seconds into the future every time.
```
