### PR TITLE
Pushback messages

### DIFF
--- a/message_server/server.py
+++ b/message_server/server.py
@@ -49,7 +49,7 @@ class Server:
         if new_sink_name in fullnames:
             raise ValueError("this sink is already loaded")
 
-        sink = new_sink()
+        sink = new_sink(self)
         self.sinks.append(sink)
 
     def find_sink(self, sink):

--- a/message_server/sink.py
+++ b/message_server/sink.py
@@ -47,7 +47,11 @@ class Sink:
                       process
     """
 
-    def __init__(self):
+    def __init__(self, server):
+        # NB: We can't reject a garbage server since doing so would require
+        # circular-importing Server (since Server imports Sink)
+        self.server = server
+
         self.types = set()
 
         self.add_type = TypeValidator(self.types.add)
@@ -74,6 +78,7 @@ class SimpleSink(Sink):
     tolerate recusrion (i.e., your message() function will indirectly call
     itself.
     """
+
     def push_message(self, message):
         if not isinstance(message, Message):
             raise TypeError("message must be a Message object")
@@ -89,8 +94,8 @@ class ThreadedSink(Sink, threading.Thread):
     achieve this. Therefore, the requirements of a SimpleSink do not apply.
     """
 
-    def __init__(self):
-        Sink.__init__(self)
+    def __init__(self, server):
+        Sink.__init__(self, server)
         threading.Thread.__init__(self)
         self.daemon = True
         self.queue = Queue.Queue()

--- a/message_server/tests/pushback.py
+++ b/message_server/tests/pushback.py
@@ -1,0 +1,57 @@
+# Copyright 2010 (C) Daniel Richman
+#
+# This file is part of habitat.
+#
+# habitat is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# habitat is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with habitat.  If not, see <http://www.gnu.org/licenses/>.
+
+from message_server import SimpleSink, ThreadedSink, Message
+
+class PushbackSink():
+    def setup(self):
+        self.add_type(Message.RECEIVED_TELEM)
+        self.add_type(Message.TELEM)
+        self.status = 0
+
+    def message(self, message):
+        assert message.data == 6293
+
+        if self.status == 0:
+            assert message.type == Message.RECEIVED_TELEM
+            self.pbmsg = Message(message.source, Message.TELEM, message.data)
+            self.status = 1
+            self.server.push_message(self.pbmsg)
+        elif self.status == 1:
+            assert message == self.pbmsg
+            self.status = 2
+        else:
+            raise AssertionError
+
+class PushbackReceiverSink():
+    def setup(self):
+        self.add_type(Message.TELEM)
+        self.status = 0
+
+    def message(self, message):
+        assert message.data == 6293
+        assert self.status == 0
+        self.status = 2
+
+class PushbackSimpleSink(PushbackSink, SimpleSink):
+    pass
+class PushbackThreadedSink(PushbackSink, ThreadedSink):
+    pass
+class PushbackReceiverSimpleSink(PushbackReceiverSink, SimpleSink):
+    pass
+class PushbackReceiverThreadedSink(PushbackReceiverSink, ThreadedSink):
+    pass

--- a/parser/tests/test_parser_sink.py
+++ b/parser/tests/test_parser_sink.py
@@ -42,7 +42,7 @@ class Module2(ParserModule):
 
 class TestParserSink:
     def setUp(self):
-        self.sink = ParserSink()
+        self.sink = ParserSink(Server())
 
     def test_parser_has_RECEIVED_TELEM_type(self):
         """sink has RECEIVED_TELEM type"""


### PR DESCRIPTION
The server now passes itself to new sinks when they are created, and with that object (self.server) they can add messages "back into" the server.

Perhaps this could also be useful later on if the sink (e.g., Parser) needs to access self.server.config (couchdb object)
