### PR TITLE
__repr__ for message_server objects.

### DIFF
--- a/habitat/main.py
+++ b/habitat/main.py
@@ -218,7 +218,7 @@ class SignalListener:
 
      - **SIGTERM**, **SIGINT**: calls :py:meth:`Program.shutdown`
      - **SIGHUP**: calls :py:meth:`Program.reload`
-     - **SIGUSR1**: exits the py:meth:`listen` loop by
+     - **SIGUSR1**: exits the :py:meth:`listen` loop by
        calling :py:func:`sys.exit` / raising
        :py:exc:`SystemExit <exceptions.SystemExit>`
        (NB: the :py:meth:`listen` loop will be running in **MainThread**)

--- a/habitat/message_server.py
+++ b/habitat/message_server.py
@@ -528,6 +528,22 @@ class Message:
         self.type = type
         self.data = data
 
+    def __repr__(self):
+        """
+        Concisely describes the **Message**
+
+        This is primarily for help debugging from PDB or the python
+        console.
+
+        Returns something like:
+        ``<RECEIVED_TELEM habitat.message_server.Message from \
+        <habitat.message_server.Listener M0ZDR at 127.0.0.1>: \
+        {"data": "test"}``
+        """
+
+        return "<habitat.message_server.Message (%s) from %s: %s>" % \
+               (self.type_names[self.type], repr(self.source), repr(self.data))
+
     @classmethod
     def validate_type(cls, type):
         """Checks that type is an integer and a valid message type"""
@@ -582,3 +598,17 @@ class Listener:
             return self.callsign == other.callsign
         except:
             return False
+
+    def __repr__(self):
+        """
+        Concisely describes the **Listener**
+
+        This is primarily for help debugging from PDB or the python
+        console.
+
+        Returns something like:
+        ``<habitat.message_server.Listener M0ZDR at 127.0.0.1>``
+        """
+
+        return "<habitat.message_server.Listener %s at %s>" % \
+               (self.callsign, str(self.ip))

--- a/habitat/tests/test_http/test_app.py
+++ b/habitat/tests/test_http/test_app.py
@@ -30,14 +30,14 @@ class TestInsertApplication:
         server = ServerStub()
         self.messages = server.messages
         self.app = InsertApplication(server, None)
-        self.app.message("2.7.5.8", callsign="2E0DRX", type="RECEIVED_TELEM",
+        self.app.message("2.7.5.8", callsign="M0ZDR", type="RECEIVED_TELEM",
                          data="some$data")
 
     def test_message_pushes_message(self):
         assert len(self.messages) == 1
 
     def test_message_pushes_callsign_correctly(self):
-        assert self.messages[0].source.callsign == "2E0DRX"
+        assert self.messages[0].source.callsign == "M0ZDR"
 
     def test_message_pushes_ip_correctly(self):
         assert str(self.messages[0].source.ip) == "2.7.5.8"
@@ -50,7 +50,7 @@ class TestInsertApplication:
 
     @raises(ValueError)
     def test_message_refuses_forbidden_types(self):
-        self.app.message("2.7.5.8", callsign="2E0DRX", type="TELEM",
+        self.app.message("2.7.5.8", callsign="M0ZDR", type="TELEM",
                          data="haxx")
 
     @raises(ValueError)
@@ -60,12 +60,12 @@ class TestInsertApplication:
 
     @raises(ValueError)
     def test_message_raises_message_type_errors(self):
-        self.app.message("2.7.5.8", callsign="2E0DRX", type="NOT_A_TYPE",
+        self.app.message("2.7.5.8", callsign="M0ZDR", type="NOT_A_TYPE",
                          data="haxx")
 
     # So that it's easy to extend/update later
     def test_message_allows_other_args(self):
-        self.app.message("2.7.5.8", callsign="2E0DRX", type="RECEIVED_TELEM",
+        self.app.message("2.7.5.8", callsign="M0ZDR", type="RECEIVED_TELEM",
                          data="some$data", cookieplease=True)
         assert len(self.messages) == 2
         self.messages.pop(1)
@@ -76,7 +76,7 @@ class TestInsertApplication:
 
     @raises(ValueError)
     def check_message_requires_arg(self, arg):
-        kwargs = { "callsign": "2E0DRX", "type": "RECEIVED_TELEM",
+        kwargs = { "callsign": "M0ZDR", "type": "RECEIVED_TELEM",
                    "data": "some$data" }
         del kwargs[arg]
         self.app.message("2.7.5.8", **kwargs)

--- a/habitat/tests/test_http/test_scgi.py
+++ b/habitat/tests/test_http/test_scgi.py
@@ -133,7 +133,7 @@ class TestSCGIStartupShutdown:
         client.close()
 
 test_message_d = {}
-test_message_d["callsign"] = "2E0DRX"
+test_message_d["callsign"] = "M0ZDR"
 test_message_d["type"] = "RECEIVED_TELEM"
 test_message_d["data"] = "$$Garbage"
 test_message = json.dumps(test_message_d)
@@ -175,7 +175,7 @@ class TestSCGIBehaviour:
         (headers, body) = scgi_req("/message", test_message)
         assert headers["Status"].startswith("200")
         assert len(self.messages) == 1
-        assert self.messages[0].source.callsign == "2E0DRX"
+        assert self.messages[0].source.callsign == "M0ZDR"
         assert self.messages[0].type == Message.RECEIVED_TELEM
         assert self.messages[0].data == "$$Garbage"
 

--- a/habitat/tests/test_message_server/locktroll.py
+++ b/habitat/tests/test_message_server/locktroll.py
@@ -19,21 +19,21 @@ import threading
 
 class LockTroll(threading.Thread):
     def __init__(self, lock):
-	threading.Thread.__init__(self)
-	self.name = "Test Thread: LockTroll"
-	self.lock = lock
-	self.stop = threading.Event()
-	self.started = threading.Event()
+        threading.Thread.__init__(self)
+        self.name = "Test Thread: LockTroll"
+        self.lock = lock
+        self.stop = threading.Event()
+        self.started = threading.Event()
 
     def start(self):
-	threading.Thread.start(self)
-	self.started.wait()
+        threading.Thread.start(self)
+        self.started.wait()
 
     def run(self):
-	with self.lock:
-	    self.started.set()
-	    self.stop.wait()
+        with self.lock:
+            self.started.set()
+            self.stop.wait()
 
     def release(self):
-	self.stop.set()
-	self.join()
+        self.stop.set()
+        self.join()

--- a/habitat/tests/test_message_server/locktroll.py
+++ b/habitat/tests/test_message_server/locktroll.py
@@ -1,0 +1,39 @@
+# Copyright 2010 (C) Daniel Richman
+#
+# This file is part of habitat.
+#
+# habitat is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# habitat is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with habitat.  If not, see <http://www.gnu.org/licenses/>.
+
+import threading
+
+class LockTroll(threading.Thread):
+    def __init__(self, lock):
+	threading.Thread.__init__(self)
+	self.name = "Test Thread: LockTroll"
+	self.lock = lock
+	self.stop = threading.Event()
+	self.started = threading.Event()
+
+    def start(self):
+	threading.Thread.start(self)
+	self.started.wait()
+
+    def run(self):
+	with self.lock:
+	    self.started.set()
+	    self.stop.wait()
+
+    def release(self):
+	self.stop.set()
+	self.join()

--- a/habitat/tests/test_message_server/test_message.py
+++ b/habitat/tests/test_message_server/test_message.py
@@ -25,7 +25,7 @@ from habitat.message_server import Message, Listener
 
 class TestMessage:
     def setup(self):
-        self.source = Listener("2E0DRX", "1.2.3.4")
+        self.source = Listener("M0ZDR", "1.2.3.4")
 
     def test_ids_exist_and_are_unique(self):
         types = set()
@@ -73,16 +73,30 @@ class TestMessage:
     def test_validate_type_accepts_valid_type(self):
         Message.validate_type(Message.LISTENER_TELEM)
 
+    def test_repr(self):
+        repr_format = "<habitat.message_server.Message (%s) from %s: %s>"
+
+        for type in Message.types:
+            for data in [None, 123, "testing", {"data": 123, "more": "asdf"}]:
+                assert repr(Message(self.source, type, data)) == \
+                    repr_format % (Message.type_names[type],
+                                   repr(self.source), repr(data))
+
 class TestListener:
     def setup(self):
         # NB: b & d have different IPs
-        self.listenera = Listener("2E0DRX", "1.2.3.4")
-        self.listenerb = Listener("2E0DRX", "1.2.3.5")
+        self.listenera = Listener("M0ZDR", "1.2.3.4")
+        self.listenerb = Listener("M0ZDR", "1.2.3.5")
         self.listenerc = Listener("M0RND", "1.2.3.4")
         self.listenerd = Listener("M0rnd", "001.2.003.5")
 
+    def test_repr(self):
+        repr_format = "<habitat.message_server.Listener %s at %s>"
+        assert repr(self.listenera) == repr_format % ("M0ZDR", "1.2.3.4")
+        assert repr(self.listenerd) == repr_format % ("M0RND", "1.2.3.5")
+
     def test_initialiser_accepts_and_stores_data(self):
-        assert self.listenerb.callsign == "2E0DRX"
+        assert self.listenerb.callsign == "M0ZDR"
         assert str(self.listenerb.ip) == "1.2.3.5"
         assert self.listenerc.callsign == "M0RND"
         assert str(self.listenerc.ip) == "1.2.3.4"
@@ -109,13 +123,13 @@ class TestListener:
 
     @raises(ValueError)
     def test_rejects_nonalphanum_callsign(self):
-        Listener("2E0DRX'; DELETE TABLE BALLOONS; --", "1.2.3.4")
+        Listener("M0ZDR'; DELETE TABLE BALLOONS; --", "1.2.3.4")
 
     @raises(ValueError) # IPAddress() failures return ValueError
     def test_rejects_invalid_ip(self):
         # We use ipaddr which is well tested, so we don't need to spend too
         # much time making sure it works.
-        Listener("2E0DRX", "1234.1.1.1")
+        Listener("M0ZDR", "1234.1.1.1")
 
     def test_ip_compares(self):
         assert self.listenera.ip == self.listenerc.ip

--- a/habitat/tests/test_message_server/test_server.py
+++ b/habitat/tests/test_message_server/test_server.py
@@ -30,6 +30,8 @@ from habitat.message_server import Sink, SimpleSink, Message, Listener
 from habitat.utils.tests.reloadable_module import ReloadableModuleWriter
 from habitat.message_server import Server
 
+from locktroll import LockTroll
+
 class FakeSink(SimpleSink):
     def setup(self):
         pass
@@ -73,25 +75,6 @@ class TestServer:
         assert self.server.message_count == 11
 
     def test_repr(self):
-        # TODO Move this into test libs when it's created.
-        class LockTroll(threading.Thread):
-            def __init__(self, lock):
-                threading.Thread.__init__(self)
-                self.name = "Test Thread: test_repr.LockTroll"
-                self.lock = lock
-                self.stop = threading.Event()
-                self.started = threading.Event()
-            def start(self):
-                threading.Thread.start(self)
-                self.started.wait()
-            def run(self):
-                with self.lock:
-                    self.started.set()
-                    self.stop.wait()
-            def release(self):
-                self.stop.set()
-                self.join()
-
         assert self.server.__class__.__name__ == "Server"
         assert self.server.__class__.__module__ == "habitat.message_server"
         expect_format = "<habitat.message_server.Server: %s>"

--- a/habitat/tests/test_message_server/test_server.py
+++ b/habitat/tests/test_message_server/test_server.py
@@ -63,7 +63,7 @@ class NonSink:
 class TestServer:
     def setup(self):
         self.server = Server(None, None)
-        self.source = Listener("2E0DRX", "1.2.3.4")
+        self.source = Listener("M0ZDR", "1.2.3.4")
 
     def test_message_counter(self):
         message_rt = Message(self.source, Message.RECEIVED_TELEM, None)

--- a/habitat/tests/test_message_server/test_sink.py
+++ b/habitat/tests/test_message_server/test_sink.py
@@ -124,7 +124,7 @@ class ThreadedPush(threading.Thread):
 
 class TestSink:
     def setup(self):
-        self.source = Listener("2E0DRX", "1.2.3.4")
+        self.source = Listener("M0ZDR", "1.2.3.4")
 
     @raises(TypeError)
     def test_init_rejects_garbage_server(self):


### PR DESCRIPTION
Perhaps if statistics/counters were added to the classes in habitat/http then **repr** methods for those objects would be appropriate; however, for the meantime, I don't think that the classes other than those in message_server could usefully benefit from **repr**.
