### PR TITLE
Couchdb Permissions

### DIFF
--- a/couchdb/habitat/validate_doc_update.js
+++ b/couchdb/habitat/validate_doc_update.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 (C) Adam Greig
+ * Copyright 2011 (C) Daniel Richman, Adam Greig
  *
  * This file is part of habitat.
  *
@@ -17,14 +17,35 @@
  * along with habitat.  If not, see <http://www.gnu.org/licenses/>.
  */
 function(newDoc, oldDoc, userCtx) {
-    // Forbid deleting documents
-    if(newDoc._deleted)
-        throw({forbidden: "Documents may not be deleted."});
+    if (userCtx.roles.indexOf('_admin') !== -1)
+    {
+        // Admins may do what they like
+        return;
+    }
+    else if (userCtx.name == "habitat")
+    {
+        // The habitat user can do what it likes to everything except
+        // config and flight documents, except delete them
 
-    // Changing or creating documents is totally forbidden, unless:
-    //   you are the habitat user
-    //   you are an admin
-    if (userCtx.name != "habitat" && userCtx.roles.indexOf('_admin') === -1)
+        if (newDoc._deleted)
+            throw({forbidden: "Documents may not be deleted."});
+
+        if (newDoc.type == "config" || (oldDoc && oldDoc.type == "config"))
+            throw({forbidden: "Only administrators may edit config docs"});
+
+        if (newDoc.type == "flight" || (oldDoc && oldDoc.type == "flight"))
+            throw({forbidden: "Only administrators may edit flight docs"});
+
+        // If nothing's been thrown; it's fine.
+        return;
+    }
+    // To be added:
+    // else if (oldDoc && oldDoc.type == "flight" && oldDoc.editors &&
+    //          oldDoc.editors.indexOf(userCtx.name) !== -1)
+    //   -- Test to make sure they haven't modified the editors list.
+    //   -- Only let them modify certain things, like sentence, not callsign.
+    else
+    {
         throw({forbidden: "You do not have permission to edit documents"});
+    }
 }
-

--- a/couchdb/habitat/validate_doc_update.js
+++ b/couchdb/habitat/validate_doc_update.js
@@ -59,6 +59,8 @@ function(newDoc, oldDoc, userCtx) {
        // like sentence, not callsign or project name or whatever.
        //
        // TODO: Maybe require some basic checks on their data?
+
+       throw({forbidden: "Not yet implemented"});
     }
     else
     {

--- a/couchdb/habitat/validate_doc_update.js
+++ b/couchdb/habitat/validate_doc_update.js
@@ -39,11 +39,27 @@ function(newDoc, oldDoc, userCtx) {
         // If nothing's been thrown; it's fine.
         return;
     }
-    // To be added:
-    // else if (oldDoc && oldDoc.type == "flight" && oldDoc.editors &&
-    //          oldDoc.editors.indexOf(userCtx.name) !== -1)
-    //   -- Test to make sure they haven't modified the editors list.
-    //   -- Only let them modify certain things, like sentence, not callsign.
+    else if (oldDoc && oldDoc.type == "flight" && oldDoc.editors &&
+             oldDoc.editors.indexOf(userCtx.name) !== -1)
+    {
+        // Named editors may modify a flight document in certain (limited)
+        // ways.
+
+        var oldEditors = oldDoc.editors.sort();
+        var newEditors = newDoc.editors.sort();
+
+        if (oldEditors.length !== newEditors.length)
+            throw({forbidden: "Only administrators may edit editors"});
+
+        for (var i = 0; i < oldEditors.length; i++)
+            if (oldEditors[i] !== newEditors[i])
+                throw({forbidden: "Only administrators may edit editors"});
+
+       // TODO: Only let them modify certain things,
+       // like sentence, not callsign or project name or whatever.
+       //
+       // TODO: Maybe require some basic checks on their data?
+    }
     else
     {
         throw({forbidden: "You do not have permission to edit documents"});

--- a/couchdb/habitat/validate_doc_update.js
+++ b/couchdb/habitat/validate_doc_update.js
@@ -21,10 +21,10 @@ function(newDoc, oldDoc, userCtx) {
     if(newDoc._deleted)
         throw({forbidden: "Documents may not be deleted."});
 
-    // Forbid changing/creating documents such as telemetry
-    // or listener information unless you are the habitat user
-    // (all such documents should go through the habitat backend)
-    if(newDoc.type != "flight" && userCtx.name != "habitat")
+    // Changing or creating documents is totally forbidden, unless:
+    //   you are the habitat user
+    //   you are an admin
+    if (userCtx.name != "habitat" && userCtx.roles.indexOf('_admin') === -1)
         throw({forbidden:
                 "Only the habitat user may create non-flight documents"});
 }

--- a/couchdb/habitat/validate_doc_update.js
+++ b/couchdb/habitat/validate_doc_update.js
@@ -25,7 +25,6 @@ function(newDoc, oldDoc, userCtx) {
     //   you are the habitat user
     //   you are an admin
     if (userCtx.name != "habitat" && userCtx.roles.indexOf('_admin') === -1)
-        throw({forbidden:
-                "Only the habitat user may create non-flight documents"});
+        throw({forbidden: "You do not have permission to edit documents"});
 }
 


### PR DESCRIPTION
I'm opening a pull request so that this can be discussed rather than merged, but if you agree then go ahead.

I think that only admins and habitat should be allowed to make any changes to the database; admins could need to edit documents other than config & flight docs in the name of spam control.

We may want to add the use of roles, or the ability to give a user the ability to edit a single flight document, etc. in the future.

Perhaps habitat shouldn't be allowed to edit flight or config docs.
