### PR TITLE
changed restkit's logging level to WARNING

### DIFF
--- a/habitat/main.py
+++ b/habitat/main.py
@@ -45,8 +45,6 @@ from habitat.utils import crashmat
 __all__ = ["get_options", "setup_logging", "Program", "SignalListener"]
 
 logger = logging.getLogger("habitat.main")
-restkit_logger = logging.getLogger("restkit")
-logger_warning = logging.WARNING
 
 usage = "%prog [options]"
 version = "{0} {1}".format(habitat.__name__, habitat.__version__)
@@ -215,7 +213,7 @@ def setup_logging(log_stderr_level, log_file_name, log_file_level):
     #     are both nabbed at the top of this script and put into the global
     #     namespace. nose appears to overwrite logging with a FakeLogging
     #     module which lacks logging.WARNING and logging.getLogger(name)
-    restkit_logger.setLevel(logger_warning)
+    logging.getLogger("restkit").setLevel(logging.WARNING)
 
     have_handlers = False
 

--- a/habitat/main.py
+++ b/habitat/main.py
@@ -45,6 +45,8 @@ from habitat.utils import crashmat
 __all__ = ["get_options", "setup_logging", "Program", "SignalListener"]
 
 logger = logging.getLogger("habitat.main")
+restkit_logger = logging.getLogger("restkit")
+logger_warning = logging.WARNING
 
 usage = "%prog [options]"
 version = "{0} {1}".format(habitat.__name__, habitat.__version__)
@@ -207,6 +209,13 @@ def setup_logging(log_stderr_level, log_file_name, log_file_level):
     # Enable all messages at the logger level, then filter them in each
     # handler.
     root_logger.setLevel(logging.DEBUG)
+
+    # Bug pivotal:11844615, set restkit's level to WARNING to lower spam
+    # Due to nosetests being very odd, restkit_logger and logger_warning
+    #     are both nabbed at the top of this script and put into the global
+    #     namespace. nose appears to overwrite logging with a FakeLogging
+    #     module which lacks logging.WARNING and logging.getLogger(name)
+    restkit_logger.setLevel(logger_warning)
 
     have_handlers = False
 

--- a/tests/test_habitat/test_main/test_setup_logging.py
+++ b/tests/test_habitat/test_main/test_setup_logging.py
@@ -27,12 +27,19 @@ from habitat import main
 
 class FakeLogging:
     DEBUG = logging.DEBUG
+    WARNING = logging.WARNING
 
     def __init__(self):
         self.rt = self.Logger()
+        self.restkitlogger = self.Logger()
 
-    def getLogger(self):
-        return self.rt
+    def getLogger(self, name=None):
+        if name == None:
+            return self.rt
+        elif name == "restkit":
+            return self.restkitlogger
+        else:
+            raise ValueError("Requested an unexpected logger")
 
     class Logger:
         def __init__(self):


### PR DESCRIPTION
(pivotal bug https://www.pivotaltracker.com/story/show/11844615 )

note that for whatever reason nosetests appears to override logging with a FakeLogging which doesn't provide WARNING or getLogger(name), only DEBUG and getLogger()? But if I catch things from logging just after import, in the global namespace before functions get run, it gets them from the real logging and stuff works.
