### PR TITLE
adds null_logger class for null logging, fixing issue 60

### DIFF
--- a/habitat/main.py
+++ b/habitat/main.py
@@ -234,7 +234,7 @@ def setup_logging(log_stderr_level, log_file_name, log_file_level):
     if not have_handlers:
         # logging gets annoyed if there isn't atleast one handler.
         # If we're meant to be totally silent...
-        root_logger.addHandler(logging.NullHandler())
+        root_logger.addHandler(null_logger())
 
     logger.info("Log initalised")
 
@@ -477,3 +477,8 @@ class SignalListener(object):
             self.program.reload()
         elif signum == signal.SIGUSR1:
             sys.exit()
+
+class null_logger(logging.Handler):
+    def emit(self, record):
+        pass
+

--- a/tests/test_habitat/test_main/test_setup_logging.py
+++ b/tests/test_habitat/test_main/test_setup_logging.py
@@ -64,10 +64,6 @@ class FakeLogging:
         # Expect no arguments to initialiser.
         pass
 
-    class NullHandler:
-        # Don't let it call setLevel or anything
-        pass
-
     class Formatter:
         def __init__(self, formatstring, dateformatstring=None):
             self.formatstring = formatstring
@@ -129,4 +125,4 @@ class TestSetupLogging:
         main.setup_logging(None, None, None)
         assert len(main.logging.rt.handlers) == 1
         assert isinstance(main.logging.rt.handlers[0],
-                          main.logging.NullHandler)
+                          main.null_logger)


### PR DESCRIPTION
added a null_logger class to main which is used for null logging, as logging.NullLogger may not exist. updated test for this scenario, too. closes #60
