### PR TITLE
fixes issue with invalid logging level names, fixing issue 61

### DIFF
--- a/habitat/main.py
+++ b/habitat/main.py
@@ -188,7 +188,7 @@ def get_options_parse_log_level(level):
     elif level in LOG_LEVELS:
         return getattr(logging, level)
     else:
-        parser.error("invalid value for \"{0}\"".format(levelarg))
+        parser.error("Invalid log level \"{0}\"".format(level))
 
 def setup_logging(log_stderr_level, log_file_name, log_file_level):
     """

--- a/tests/test_habitat/test_main/test_options.py
+++ b/tests/test_habitat/test_main/test_options.py
@@ -246,6 +246,12 @@ class TestOptions:
 
         self.check_get_options_fails(argv)
 
+    def test_invalid_level_names(self):
+        # Fixes #61
+        self.check_get_options_fails(
+            ["-c", "c", "-d", "d", "-s", "s", "--secret", "secret",
+             "-v", "INVALIDLEVEL", "-l", "/tmp/test", "-e", "ERROR"])
+
     def test_log_levels(self):
         levels = [("CRITICAL", logging.CRITICAL),
                   ("ERROR", logging.ERROR),


### PR DESCRIPTION
fixed code path when an invalid level name is given and added a test for this. closes #61
