### PR TITLE
Parser Tweaks

### DIFF
--- a/habitat/parser.py
+++ b/habitat/parser.py
@@ -84,7 +84,7 @@ class Parser(object):
 
         self.couch_server = couchdbkit.Server(config["couch_uri"])
         self.db = self.couch_server[config["couch_db"]]
-        self.last_seq = 0
+        self.last_seq = self.db.info()["update_seq"]
 
     def run(self):
         """

--- a/habitat/parser.py
+++ b/habitat/parser.py
@@ -314,15 +314,20 @@ class Parser(object):
         Returns the filtered data, or leaves the data untouched
         if the filter could not be run.
         """
-        if "type" not in f:
-            logger.warning("A filter didn't have a type: " + repr(f))
-            return data
-        if f["type"] == "normal":
-            return self._normal_filter(data, f)
-        elif f["type"] == "hotfix":
-            return self._hotfix_filter(data, f)
-        else:
-            return data
+        
+        rollback = data
+        data = copy.deepcopy(data)
+
+        try:
+            if f["type"] == "normal":
+                return self._normal_filter(data, f)
+            elif f["type"] == "hotfix":
+                return self._hotfix_filter(data, f)
+            else:
+                raise ValueError("Invalid filter type")
+        except:
+            logger.exception("Error while applying filter " + repr(f))
+            return rollback
 
     def _normal_filter(self, data, f):
         """Load and run a filter specified by a callable."""
@@ -330,37 +335,26 @@ class Parser(object):
         if "config" in f:
             config = f["config"]
 
-        try:
-            fil = dynamicloader.load(f["callable"])
-        except ImportError:
-            logger.warning("Could not import filter: " + repr(f))
-            return data
-        if not dynamicloader.iscallable(fil):
-            logger.warning("A loaded filter wasn't callable: " + repr(f))
-            return data
+        fil = dynamicloader.load(f["callable"])
+        assert dynamicloader.iscallable(fil)
+
         if dynamicloader.hasnumargs(fil, 1):
             return fil(data)
         elif dynamicloader.hasnumargs(fil, 2):
             return fil(data, config)
         else:
-            logger.warning("A loaded filter had wrong number of args: " +
-                    repr(f))
-            return data
+            raise TypeError("The loaded filter had the wrong number of args")
 
     def _sanity_check_hotfix(self, f):
         """Perform basic sanity checks on **f**"""
         if "code" not in f:
-            err = "Hotfix didn't have any code: " + repr(f)
-            raise ValueError(err)
+            raise ValueError("Hotfix didn't have any code")
         if "signature" not in f:
-            err = "Hotfix didn't have a signature: " + repr(f)
-            raise ValueError(err)
+            raise ValueError("Hotfix didn't have a signature")
         if "certificate" not in f:
-            err = "Hotfix didn't specify a certificate: " + repr(f)
-            raise ValueError(err)
+            raise ValueError("Hotfix didn't specify a certificate")
         if os.path.basename(f["certificate"]) != f["certificate"]:
-            err = "Hotfix's specified certificate was invalid: " + repr(f)
-            raise ValueError(err)
+            raise ValueError("Hotfix's specified certificate was invalid")
 
     def _verify_certificate(self, f, cert):
         """Check that the certificate is cryptographically signed by a key
@@ -398,44 +392,19 @@ class Parser(object):
         """Load a filter specified by some code in the database. Check its
         authenticity by verifying its certificate, then run if OK."""
         # Check the hotfix has all the right fields
-        try:
-            self._sanity_check_hotfix(f)
-        except ValueError as e:
-            logger.warning(e)
-            return data
+        self._sanity_check_hotfix(f)
         
         # Load requested certificate
-        try:
-            cert = self._get_certificate(f["certificate"])
-        except RuntimeError:
-            err = "Could not load certificate ''{0}''."
-            logger.warning(err.format(f["certificate"]))
-            return data
+        cert = self._get_certificate(f["certificate"])
         
         # Check the certificate and signature are cryptographically okay
-        try:
-            self._verify_certificate(f, cert)
-        except ValueError as e:
-            logger.warning(e)
-            return data
+        self._verify_certificate(f, cert)
         
         # Compile the hotfix
-        try:
-            env = self._compile_hotfix(self, f)
-        except ValueError as e:
-            logger.warning(e)
-            return data
+        env = self._compile_hotfix(self, f)
 
-        logger.debug("Hotfix compiled, executing")
-        try:
-            return env["f"](data)
-        except:
-            # this is a pretty hardcore except! it'l catch anything.
-            # but that's desirable as who knows what this crazy code
-            # might do.
-            err = "An exception occured while running a hotfix: " + repr(f)
-            logger.warning(err)
-            return data
+        logger.debug("Executing a hotfix")
+        return env["f"](data)
     
     def _get_certificate(self, certname):
         """Fetch the specified certificate, returning the X509 object.

--- a/habitat/tests/test_parser/test_parser.py
+++ b/habitat/tests/test_parser/test_parser.py
@@ -40,7 +40,19 @@ class TestParser(object):
             {"name": "Mock", "class": MockModule}],
             "sensors": [], "certs_dir": "habitat/tests/test_parser/certs",
             "couch_uri": "http://localhost:5984", "couch_db": "test"}
+
+        self.m.StubOutWithMock(parser, 'couchdbkit')
+        self.mock_server = self.m.CreateMock(couchdbkit.Server)
+        self.mock_db = self.m.CreateMock(couchdbkit.Database)
+        parser.couchdbkit.Server("http://localhost:5984")\
+                .AndReturn(self.mock_server)
+        self.mock_server.__getitem__("test").AndReturn(self.mock_db)
+        self.mock_db.info().AndReturn({"update_seq": 191238})
+
+        self.m.ReplayAll()
         self.parser = parser.Parser(self.parser_config)
+        self.m.VerifyAll()
+        self.m.ResetAll()
 
     def teardown(self):
         self.m.UnsetStubs()
@@ -109,20 +121,15 @@ class TestParser(object):
         assert_raises(ValueError, parser.Parser, config)
 
     def test_init_connects_to_couch(self):
-        self.m.StubOutWithMock(parser, 'couchdbkit')
-        s = self.m.CreateMock(couchdbkit.Server)
-        parser.couchdbkit.Server("http://localhost:5984").AndReturn(s)
-        s.__getitem__("test")
-        self.m.ReplayAll()
-        parser.Parser(self.parser_config)
-        self.m.VerifyAll()
+        # This actually tested by setup(), since the parser needs to be
+        # initialised with CouchDB mocks in all other tests.
+        assert self.parser.db == self.mock_db
 
-    def test_run_calls_wait(self):
-        self.m.StubOutWithMock(parser, 'couchdbkit')
+    def test_run_calls_wait_and_uses_update_seq(self):
         c = self.m.CreateMock(couchdbkit.Consumer)
         parser.couchdbkit.Consumer(self.parser.db).AndReturn(c)
-        c.wait(self.parser._couch_callback, filter="habitat/unparsed", since=0,
-                include_docs=True, heartbeat=1000)
+        c.wait(self.parser._couch_callback, filter="habitat/unparsed",
+               since=191238, include_docs=True, heartbeat=1000)
         self.m.ReplayAll()
         self.parser.run()
         self.m.VerifyAll()
@@ -142,7 +149,6 @@ class TestParser(object):
         orig_doc = {"_id": "id", "receivers": [1], 'data': {'a': 1}}
         parsed_doc = deepcopy(orig_doc)
         parsed_doc['data']['b'] = 2
-        self.m.StubOutWithMock(self.parser, 'db')
         self.parser.db.__getitem__('id').AndReturn(orig_doc)
         self.parser.db.save_doc(parsed_doc)
         self.m.ReplayAll()
@@ -157,7 +163,6 @@ class TestParser(object):
         updated_doc['receivers'].append(2)
         merged_doc = deepcopy(parsed_doc)
         merged_doc['receivers'] = deepcopy(updated_doc['receivers'])
-        self.m.StubOutWithMock(self.parser, 'db')
         self.parser.db.__getitem__('id').AndReturn(updated_doc)
         self.parser.db.save_doc(merged_doc)
         self.m.ReplayAll()
@@ -172,7 +177,6 @@ class TestParser(object):
         updated_doc['receivers'].append(2)
         merged_doc = deepcopy(parsed_doc)
         merged_doc['receivers'] = deepcopy(updated_doc['receivers'])
-        self.m.StubOutWithMock(self.parser, 'db')
         self.parser.db.__getitem__('id').AndReturn(orig_doc)
         self.parser.db.save_doc(parsed_doc).AndRaise(
             couchdbkit.exceptions.ResourceConflict())
@@ -186,7 +190,6 @@ class TestParser(object):
         orig_doc = {"_id": "id", "receivers": [1], 'data': {'a': 1}}
         parsed_doc = deepcopy(orig_doc)
         parsed_doc['data']['b'] = 2
-        self.m.StubOutWithMock(self.parser, 'db')
         for i in xrange(30):
             self.parser.db.__getitem__('id').AndReturn(orig_doc)
             self.parser.db.save_doc(parsed_doc).AndRaise(
@@ -196,7 +199,6 @@ class TestParser(object):
         self.m.VerifyAll()
 
     def test_looks_for_config_doc(self):
-        self.m.StubOutWithMock(self.parser, 'db')
         callsign = "habitat"
         time_created = 1234567890
         view_result = {'doc': {'payloads': {callsign: True}}}
@@ -211,7 +213,6 @@ class TestParser(object):
         self.m.VerifyAll()
 
     def test_doesnt_use_bad_config_doc(self):
-        self.m.StubOutWithMock(self.parser, 'db')
         callsign = "habitat"
         time_created = 1234567890
         view_result = {'doc': {'payloads': {"not habitat": True}}}

--- a/habitat/tests/test_parser/test_parser.py
+++ b/habitat/tests/test_parser/test_parser.py
@@ -410,20 +410,20 @@ class TestParser(object):
     def test_uncallable_normal_filters(self):
         class F:
             pass
-        f = {'callable': F}
-        assert self.parser._normal_filter('test string', f) == 'test string'
+        f = {'callable': F, 'type': 'normal'}
+        assert self.parser._filter('test string', f) == 'test string'
 
     def test_unimportable_normal_filters(self):
-        f = {'callable': 'fakefakefake.fakepath.is.fake'}
-        assert self.parser._normal_filter('test string', f) == 'test string'
+        f = {'callable': 'fakefakefake.fakepath.is.fake', 'type': 'normal'}
+        assert self.parser._filter('test string', f) == 'test string'
 
     def test_incorrect_num_args_normal_filters(self):
         def fil(data, config, too, many, args):
             assert data == 'test string'
             assert config == 'config'
             return 'filtered'
-        f = {'callable': fil, 'config': 'config'}
-        assert self.parser._normal_filter('test string', f) == 'test string'
+        f = {'callable': fil, 'config': 'config', 'type': 'normal'}
+        assert self.parser._filter('test string', f) == 'test string'
 
     def test_hotfix_filters(self):
         self.m.StubOutWithMock(self.parser, '_sanity_check_hotfix')
@@ -445,18 +445,18 @@ class TestParser(object):
         self.m.StubOutWithMock(self.parser, '_get_certificate')
         self.m.StubOutWithMock(self.parser, '_verify_certificate')
         self.m.StubOutWithMock(self.parser, '_compile_hotfix')
-        f = {'certificate': 'cert'}
-        def OhNoError(Exception):
+        f = {'certificate': 'cert', 'type': 'hotfix'}
+        class OhNoError(Exception):
             pass
         def hotfix(data):
-            raise OhNoError()
+            raise OhNoError
         env = {'f': hotfix}
         self.parser._sanity_check_hotfix(f)
         self.parser._get_certificate('cert').AndReturn('got_cert')
         self.parser._verify_certificate(f, 'got_cert')
         self.parser._compile_hotfix(self.parser, f).AndReturn(env)
         self.m.ReplayAll()
-        assert self.parser._hotfix_filter('unfiltered', f) == 'unfiltered'
+        assert self.parser._filter('unfiltered', f) == 'unfiltered'
         self.m.VerifyAll()
 
     def test_handles_hotfix_syntax_error(self):


### PR DESCRIPTION
Included:
- parse from update_seq (i.e., future changes) rather than the beginning of time. TODO: admin interface to 'reparse' documents (i.e., save w. no changes to force it to appear in _changes, and/or set 'parsed' to false)
- rearrange filter exceptions: move catching and logging into one place. required rearranging the tests to call _filter, which does the catching.

In a couple of places the changes are a bit intrusive; feel free to say if you object to the way I've done something.
