### PR TITLE
added significant figure rounding to numeric_scale filter

### DIFF
--- a/habitat/filters.py
+++ b/habitat/filters.py
@@ -1,4 +1,4 @@
-# Copyright 2011 (C) Adam Greig, Daniel Richman
+# Copyright 2011 (C) Adam Greig, Daniel Richman, Priyesh Patel
 #
 # This file is part of habitat.
 #
@@ -29,6 +29,7 @@ load them for use.
 """
 
 from .utils import filtertools
+import math
 
 __all__ = ["semicolons_to_commas", "numeric_scale", "simple_map"]
 
@@ -64,6 +65,10 @@ def _post_singlefield(config):
 
     return (source, destination)
 
+def _round_significant(value, significance):
+    position = int(significance - math.ceil(math.log10(abs(value)))) 
+    return round(value, position)
+
 
 def numeric_scale(config, data):
     """
@@ -88,6 +93,12 @@ def numeric_scale(config, data):
 
     source = float(data[source_key])
     data[destination_key] = source * factor
+
+    if "round" in config:
+        significance = int(config["round"])
+        data[destination_key] = _round_significant(data[destination_key],
+                significance)
+
     return data
 
 

--- a/habitat/filters.py
+++ b/habitat/filters.py
@@ -76,7 +76,8 @@ def numeric_scale(config, data):
 
     ``data[config["source"]]`` is multiplied by ``config["factor"]`` and
     written back to ``data[config["destination"]]`` if it exists, or
-    ``data[config["source"]]`` if not.
+    ``data[config["source"]]`` if not. ``config["offset"]`` is also optionally
+    applied along with ``config["round"]``.
 
     >>> config = {"source": "key", "factor": 2.0}
     >>> data = {"key": "4", "other": "data"}
@@ -89,10 +90,15 @@ def numeric_scale(config, data):
     True
     """
     (source_key, destination_key) = _post_singlefield(config)
-    factor = float(config["factor"])
 
+    factor = float(config["factor"])
     source = float(data[source_key])
-    data[destination_key] = source * factor
+    offset = float(0.0)
+
+    if "offset" in config:
+        offset = float(config["offset"])
+
+    data[destination_key] = (source * factor) + offset
 
     if "round" in config:
         significance = int(config["round"])

--- a/habitat/tests/test_filters.py
+++ b/habitat/tests/test_filters.py
@@ -46,6 +46,12 @@ class TestFilters:
         fixed = f.numeric_scale(config, data)
         assert fixed == {"key": 7.1429, "something": True}
 
+    def test_numeric_scale_offset(self):
+        config = {"source": "key", "factor": (1.0 / 7.0), "offset": -5}
+        data = {"key": 49, "something": True}
+        fixed = f.numeric_scale(config, data)
+        assert fixed == {"key": 2, "something": True}
+
     def test_simple_map(self):
         config = {"source": "key", "destination": "key_thing",
                   "map": {48: "test", 49: "something"}}

--- a/habitat/tests/test_filters.py
+++ b/habitat/tests/test_filters.py
@@ -1,4 +1,4 @@
-# Copyright 2011 (C) Daniel Richman
+# Copyright 2011 (C) Daniel Richman, Priyesh Patel
 #
 # This file is part of habitat.
 #
@@ -39,6 +39,12 @@ class TestFilters:
         data = {"key": 49, "something": True}
         fixed = f.numeric_scale(config, data)
         assert fixed == {"key": 7, "something": True}
+
+    def test_numeric_scale_rounding(self):
+        config = {"source": "key", "factor": (1.0 / 7.0), "round": 5}
+        data = {"key": 50, "something": True}
+        fixed = f.numeric_scale(config, data)
+        assert fixed == {"key": 7.1429, "something": True}
 
     def test_simple_map(self):
         config = {"source": "key", "destination": "key_thing",


### PR DESCRIPTION
Added an option for rounding to a specified number of significant figures in the `numeric_scale` filter. 

This covers most cases, however, as we're using floating point numbers, there is the odd scenario where you'll still see lots of decimal places. This will probably have to be sorted by the spacenear.us uploader.

[With reference to issue #179]
