### PR TITLE
Immortality

### DIFF
--- a/habitat/parser.py
+++ b/habitat/parser.py
@@ -177,7 +177,7 @@ class Parser(object):
             receiver_callsign = doc['receivers'].keys()[0]
             time_created = doc['receivers'][receiver_callsign]['time_created']
         except (KeyError, IndexError) as e:
-            logger.warning("Could not find required key in doc: " + e)
+            logger.warning("Could not find required key in doc: " + str(e))
             return None
         raw_data = base64.b64decode(original_data)
 

--- a/habitat/parser.py
+++ b/habitat/parser.py
@@ -30,7 +30,7 @@ import re
 import json
 
 from . import loadable_manager
-from .utils import dynamicloader
+from .utils import dynamicloader, immortal_changes
 
 logger = logging.getLogger("habitat.parser")
 
@@ -101,7 +101,7 @@ class Parser(object):
         Start a continuous connection to CouchDB's _changes feed, watching for
         new unparsed telemetry.
         """
-        consumer = couchdbkit.Consumer(self.db)
+        consumer = immortal_changes.Consumer(self.db)
         consumer.wait(self._couch_callback, filter="habitat/unparsed",
                 since=self.last_seq, include_docs=True, heartbeat=1000)
 

--- a/habitat/tests/test_parser/test_parser.py
+++ b/habitat/tests/test_parser/test_parser.py
@@ -28,6 +28,8 @@ import M2Crypto
 from copy import deepcopy
 from nose.tools import assert_raises
 
+from ...utils import immortal_changes
+
 from ... import parser
 
 
@@ -48,6 +50,7 @@ class TestParser(object):
             "couch_uri": "http://localhost:5984", "couch_db": "test"}
 
         self.m.StubOutWithMock(parser, 'couchdbkit')
+        self.m.StubOutWithMock(parser, 'immortal_changes')
         self.mock_server = self.m.CreateMock(couchdbkit.Server)
         self.mock_db = self.m.CreateMock(couchdbkit.Database)
         parser.couchdbkit.Server("http://localhost:5984")\
@@ -134,8 +137,8 @@ class TestParser(object):
         assert self.parser.db == self.mock_db
 
     def test_run_calls_wait_and_uses_update_seq(self):
-        c = self.m.CreateMock(couchdbkit.Consumer)
-        parser.couchdbkit.Consumer(self.parser.db).AndReturn(c)
+        c = self.m.CreateMock(immortal_changes.Consumer)
+        parser.immortal_changes.Consumer(self.parser.db).AndReturn(c)
         c.wait(self.parser._couch_callback, filter="habitat/unparsed",
                since=191238, include_docs=True, heartbeat=1000)
         self.m.ReplayAll()

--- a/habitat/tests/test_utils/test_immortal_changes.py
+++ b/habitat/tests/test_utils/test_immortal_changes.py
@@ -121,7 +121,7 @@ class TestParser(object):
     def test_handles_couch_exceptions(self):
         self.backend(mox.IgnoreArg(), since=0).AndRaise(IOError)
         self.exc("Exception from changes (couch)")
-        self.sleep(1)
+        self.sleep(2)
         self.backend(mox.IgnoreArg(), since=0).AndRaise(SystemExit)
 
         self.m.ReplayAll()
@@ -147,7 +147,7 @@ class TestParser(object):
         self.cb({"seq": 24, "changes": []})
         self.cb({"seq": 25, "changes": []})
         self.exc("Exception from changes (couch)")
-        self.sleep(1)
+        self.sleep(2)
         self.backend(mox.IgnoreArg(), since=25).WithSideEffects(callbacks_b)
         self.cb({"seq": 26, "changes": []})
 
@@ -161,7 +161,7 @@ class TestParser(object):
         self.m.VerifyAll()
 
     def test_backs_off(self):
-        for length in [1, 2, 4, 8, 16, 32, 60, 60, 60]:
+        for length in [2, 4, 8, 16, 32, 60, 60, 60]:
             self.backend(mox.IgnoreArg(), since=0).AndRaise(IOError)
             self.exc("Exception from changes (couch)")
             self.sleep(length)
@@ -173,7 +173,7 @@ class TestParser(object):
         self.backend(mox.IgnoreArg(), since=0).WithSideEffects(callbacks)
         self.cb({"seq": 2, "changes": []})
         self.exc("Exception from changes (couch)")
-        self.sleep(1)
+        self.sleep(2)
         self.backend(mox.IgnoreArg(), since=2).AndRaise(SystemExit)
 
         self.m.ReplayAll()

--- a/habitat/tests/test_utils/test_immortal_changes.py
+++ b/habitat/tests/test_utils/test_immortal_changes.py
@@ -1,0 +1,186 @@
+# Copyright 2012 (C) Daniel Richman
+#
+# This file is part of habitat.
+#
+# habitat is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# habitat is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with habitat.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Tests for habitat.utils.immortal_changes
+"""
+
+import mox
+import couchdbkit
+import time
+
+from nose.tools import assert_raises
+
+from ...utils import immortal_changes
+
+
+class DummyConsumer(object):
+    # couchdbkit.Consumer, which Consumer is a subclass of, proxies
+    # all methods to a backend object (e.g., "sync"). This is the
+    # easiest way to get hold of those calls in order to test them,
+    # but it's a bit dependent on couchdbkit's internals, which sucks.
+ 
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def wait(func, **kwargs):
+        raise NotImplementedError
+
+class DummyTimeModule(object):
+    # replacing the 'time' item in immortal_changes' namespace is probably
+    # nicer than modifying the real time module.
+
+    def sleep(self, length):
+        raise NotImplementedError
+
+class TestParser(object):
+    def setup(self):
+        self.m = mox.Mox()
+
+        self.consumer = immortal_changes.Consumer(None,
+            backend='habitat.tests.test_utils.'
+                    'test_immortal_changes.DummyConsumer')
+        assert isinstance(self.consumer._consumer, DummyConsumer)
+        self.m.StubOutWithMock(self.consumer._consumer, "wait")
+
+        assert immortal_changes.time == time
+        immortal_changes.time = DummyTimeModule()
+        self.m.StubOutWithMock(immortal_changes.time, "sleep")
+
+        self.m.StubOutWithMock(immortal_changes.logger, "exception")
+
+        # for brevity.
+        self.backend = self.consumer._consumer.wait
+        self.sleep = immortal_changes.time.sleep
+        self.exc = immortal_changes.logger.exception
+        self.cb = self.m.CreateMockAnything()
+
+    def teardown(self):
+        self.m.UnsetStubs()
+
+        assert isinstance(immortal_changes.time, DummyTimeModule)
+        immortal_changes.time = time
+
+    def test_works_normally(self):
+        # Probably a good start.
+
+        def some_callbacks(cb, **kwargs):
+            cb({"seq": 2, "changes": []})
+            cb({"seq": 3, "changes": []})
+            cb({"seq": 4, "changes": []})
+            raise SystemExit
+
+        self.backend(mox.IgnoreArg(), since=0).WithSideEffects(some_callbacks)
+        self.cb({"seq": 2, "changes": []})
+        self.cb({"seq": 3, "changes": []})
+        self.cb({"seq": 4, "changes": []})
+
+        self.m.ReplayAll()
+
+        try:
+            self.consumer.wait(self.cb)
+        except SystemExit:
+            pass
+
+        self.m.VerifyAll()
+
+    def test_handles_callback_exceptions(self):
+        def some_callbacks(cb, **kwargs):
+            cb({"seq": 2, "changes": []})
+            cb({"seq": 3, "changes": []})
+            raise SystemExit
+
+        self.backend(mox.IgnoreArg(), since=0).WithSideEffects(some_callbacks)
+        self.cb({"seq": 2, "changes": []}).AndRaise(KeyError)
+        self.exc("Exception from changes callback")
+        self.cb({"seq": 3, "changes": []})
+
+        self.m.ReplayAll()
+
+        try:
+            self.consumer.wait(self.cb)
+        except SystemExit:
+            pass
+
+        self.m.VerifyAll()
+
+    def test_handles_couch_exceptions(self):
+        self.backend(mox.IgnoreArg(), since=0).AndRaise(IOError)
+        self.exc("Exception from changes (couch)")
+        self.sleep(1)
+        self.backend(mox.IgnoreArg(), since=0).AndRaise(SystemExit)
+
+        self.m.ReplayAll()
+
+        try:
+            self.consumer.wait(self.cb)
+        except SystemExit:
+            pass
+
+        self.m.VerifyAll()
+
+    def test_resumes_at_correct_seq(self):
+        def callbacks_a(cb, **kwargs):
+            cb({"seq": 24, "changes": []})
+            cb({"seq": 25, "changes": []})
+            raise IOError
+
+        def callbacks_b(cb, **kwargs):
+            cb({"seq": 26, "changes": []})
+            raise SystemExit
+
+        self.backend(mox.IgnoreArg(), since=23).WithSideEffects(callbacks_a)
+        self.cb({"seq": 24, "changes": []})
+        self.cb({"seq": 25, "changes": []})
+        self.exc("Exception from changes (couch)")
+        self.sleep(1)
+        self.backend(mox.IgnoreArg(), since=25).WithSideEffects(callbacks_b)
+        self.cb({"seq": 26, "changes": []})
+
+        self.m.ReplayAll()
+
+        try:
+            self.consumer.wait(self.cb, since=23)
+        except SystemExit:
+            pass
+
+        self.m.VerifyAll()
+
+    def test_backs_off(self):
+        for length in [1, 2, 4, 8, 16, 32, 60, 60, 60]:
+            self.backend(mox.IgnoreArg(), since=0).AndRaise(IOError)
+            self.exc("Exception from changes (couch)")
+            self.sleep(length)
+
+        def callbacks(cb, **kwargs):
+            cb({"seq": 2, "changes": []})
+            raise IOError
+
+        self.backend(mox.IgnoreArg(), since=0).WithSideEffects(callbacks)
+        self.cb({"seq": 2, "changes": []})
+        self.exc("Exception from changes (couch)")
+        self.sleep(1)
+        self.backend(mox.IgnoreArg(), since=2).AndRaise(SystemExit)
+
+        self.m.ReplayAll()
+
+        try:
+            self.consumer.wait(self.cb)
+        except SystemExit:
+            pass
+
+        self.m.VerifyAll()

--- a/habitat/utils/__init__.py
+++ b/habitat/utils/__init__.py
@@ -25,9 +25,11 @@ Various utilities for general use by ``habitat``.
     habitat.utils.dynamicloader
     habitat.utils.filtertools
     habitat.utils.startup
+    habitat.utils.immortal_changes
 """
 
 from . import checksums
 from . import dynamicloader
 from . import filtertools
 from . import startup
+from . import immortal_changes

--- a/habitat/utils/immortal_changes.py
+++ b/habitat/utils/immortal_changes.py
@@ -27,7 +27,7 @@ logger = logging.getLogger("habitat.utils.immortal_changes")
 
 class Consumer(couchdbkit.Consumer):
     def wait(self, callback, **kwargs):
-        state = {"delay": 1, "seq": 0} # scope hax.
+        state = {"delay": 2, "seq": 0} # scope hax.
 
         if "since" in kwargs:
             state["seq"] = kwargs["since"]
@@ -35,7 +35,7 @@ class Consumer(couchdbkit.Consumer):
 
         def wrapped_callback(changes):
             state["seq"] = changes["seq"]
-            state["delay"] = 1
+            state["delay"] = 2
 
             try:
                 callback(changes)

--- a/habitat/utils/immortal_changes.py
+++ b/habitat/utils/immortal_changes.py
@@ -1,0 +1,63 @@
+# Copyright 2012 (C) Daniel Richman
+#
+# This file is part of habitat.
+#
+# habitat is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# habitat is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with habitat.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+An extension to couchdbkit's changes consumer that never dies.
+"""
+
+import time
+import logging
+import couchdbkit
+
+logger = logging.getLogger("habitat.utils.immortal_changes")
+
+class Consumer(couchdbkit.Consumer):
+    def wait(self, callback, **kwargs):
+        state = {"delay": 1, "seq": 0} # scope hax.
+
+        if "since" in kwargs:
+            state["seq"] = kwargs["since"]
+            del kwargs["since"]
+
+        def wrapped_callback(changes):
+            state["seq"] = changes["seq"]
+            state["delay"] = 1
+
+            try:
+                callback(changes)
+            except (SystemExit, KeyboardInterrupt):
+                raise
+            except:
+                logger.exception("Exception from changes callback")
+
+        while True:
+            logger.debug("Starting continuous changes")
+
+            try:
+                super(Consumer, self).wait(wrapped_callback,
+                        since=state["seq"], **kwargs)
+            except (SystemExit, KeyboardInterrupt):
+                raise
+            except:
+                logger.exception("Exception from changes (couch)")
+            else:
+                logger.debug("Continuous changes connection closed")
+
+            logger.info("Sleeping for {0} seconds before restarting changes"
+                            .format(state["delay"]))
+            time.sleep(state["delay"])
+            state["delay"] = min(2 * state["delay"], 60)


### PR DESCRIPTION
Addresses
#175 parser has nothing to catch exceptions at the top prefers to just die
#154 habitat daemons watching _changes die instantly if couchdb is restarted

by subclassing couchdbkit.Consumer with something that reconnects (with an increasing back off delay) and absorbs errors in the changes callback.
