### PR TITLE
Parse time to HH:MM:SS, not dict

### DIFF
--- a/habitat/sensors/stdtelem.py
+++ b/habitat/sensors/stdtelem.py
@@ -27,11 +27,10 @@ __all__ = ["time", "coordinate"]
 
 def time(data):
     """
-    Parse the time, returning a dictionary representation.
+    Parse the time, validating it and returning the standard ``HH:MM:SS``.
 
     Accepted formats include ``HH:MM:SS``, ``HHMMSS``, ``HH:MM`` and ``HHMM``.
-
-    The returned dictionary contains keys ``hour``, ``minute`` and ``second``.
+    It uses strptime to ensure the values are sane.
     """
 
     if len(data) == 8:
@@ -45,12 +44,7 @@ def time(data):
     else:
         raise ValueError("Invalid time value.")
 
-    parsed_data = {}
-    parsed_data["hour"] = t.tm_hour
-    parsed_data["minute"] = t.tm_min
-    if len(data) == 8 or len(data) == 6:
-        parsed_data["second"] = t.tm_sec
-    return parsed_data
+    return "{0.tm_hour:02d}:{0.tm_min:02d}:{0.tm_sec:02d}".format(t)
 
 
 def coordinate(config, data):

--- a/habitat/tests/test_parser_modules/test_ukhas_parser.py
+++ b/habitat/tests/test_parser_modules/test_ukhas_parser.py
@@ -215,7 +215,7 @@ class TestUKHASParser:
         # Correct parser output for the checksum test sentences
         output_checksum_test = {
             "payload": "habitat", "message_count": 1,
-            "time": {"hour": 0, "minute": 0, "second": 0},
+            "time": "00:00:00",
             "latitude": 0.0, "longitude": 0.0, "altitude": 0,
             "speed": 0.0, "custom_string": "hab"}
 
@@ -352,7 +352,7 @@ class TestUKHASParser:
         # Correct parser output for (most) of the good sentences
         output_good = {
             "payload": "habitat", "message_count": 123,
-            "time": {"hour": 12, "minute": 45, "second": 06},
+            "time": "12:45:06",
             "latitude": -35.1032, "longitude": 138.8568,
             "altitude": 4285, "speed": 3.6, "custom_string": "hab"}
 
@@ -361,16 +361,6 @@ class TestUKHASParser:
 
         assert(self.p.parse(sentence_good_1, base_config)
                == self.output_append_sentence(output_good, sentence_good_1))
-
-        sentence_good_2 = \
-            "$$habitat,123,12:45,-35.1032,138.8568,4285,3.6,hab*8e78\n"
-
-        # Correct parser output for sentence_good_2 (no seconds on the time)
-        output_good_2 = deepcopy(output_good)
-        del output_good_2["time"]["second"]
-
-        assert(self.p.parse(sentence_good_2, base_config)
-               == self.output_append_sentence(output_good_2, sentence_good_2))
 
         sentence_good_3 = \
             "$$habitat,123,12:45:06,-3506.192,13851.408,4285,3.6,hab*6139\n"
@@ -407,7 +397,7 @@ class TestUKHASParser:
 
         output_short = {
             "payload": "habitat", "message_count": 123,
-            "time": {"hour": 12, "minute": 45, "second": 06},
+            "time": "12:45:06",
             "latitude": -35.1032, "longitude": 138.8568,
             "altitude": 4285}
 
@@ -423,7 +413,7 @@ class TestUKHASParser:
 
         output_long = {
             "payload": "habitat", "message_count": 123,
-            "time": {"hour": 12, "minute": 45, "second": 06},
+            "time": "12:45:06",
             "latitude": -35.1032, "longitude": 138.8568,
             "altitude": 4285, "speed": 3.6, "custom_string": "hab",
             "_extra_data": ["123", "4.56", "seven"]}

--- a/habitat/tests/test_sensors/test_stdtelem.py
+++ b/habitat/tests/test_sensors/test_stdtelem.py
@@ -24,27 +24,20 @@ from ...sensors import stdtelem
 
 
 class TestStdtelem:
-
-    def expected_time_output(self, t):
-        r = {"hour": t[1], "minute": t[2]}
-        if t[3] != None:
-            r["second"] = t[3]
-        return r
-
     def test_valid_times(self):
         times = [
-            ("12:00:00", 12, 0, 0),
-            ("11:15:10", 11, 15, 10),
-            ("00:00:00", 0, 0, 0),
-            ("23:59:59", 23, 59, 59),
-            ("12:00", 12, 0, None),
-            ("01:24", 1, 24, None),
-            ("123456", 12, 34, 56),
-            ("0124", 1, 24, None)
+            ("12:00:00", "12:00:00"),
+            ("11:15:10", "11:15:10"),
+            ("00:00:00", "00:00:00"),
+            ("23:59:59", "23:59:59"),
+            ("12:00",  "12:00:00"),
+            ("01:24",  "01:24:00"),
+            ("123456", "12:34:56"),
+            ("0124",   "01:24:00")
         ]
 
         for i in times:
-            assert stdtelem.time(i[0]) == self.expected_time_output(i)
+            assert stdtelem.time(i[0]) == i[1]
 
     @raises(ValueError)
     def check_invalid_time(self, s):


### PR DESCRIPTION
see #177 use "HH:MM:SS" strings in place of time dicts in generated docs

This is for time in payload_telemetry, listener_telemetry as parsed from strings or nmea. See #177 for links to commits in other repos (spacenearus uploader, dl-fldigi). Not done: transition (can do it along with the other stuff)
