### PR TITLE
Cover up Y2038 problem on 32 bit

### DIFF
--- a/habitat/utils/rfc3339.py
+++ b/habitat/utils/rfc3339.py
@@ -97,6 +97,9 @@ Notes
    In validation, seconds == 60 or seconds == 61 are rejected.
    In the case of reverse leap seconds, calendar.timegm will blisfully accept
    it. The result would be about as correct as you could get.
+ - RFC3339 generation using gmtime or localtime may be limited by the size
+   of time_t on the system: if it is 32 bit, you're limited to dates between
+   (approx) 1901 and 2038. This does not affect rfc3339_to_timestamp.
 
 """
 


### PR DESCRIPTION
:-(

since it only affects generating rfc3339 strings, y2038 won't be a problem for us until 2038 (at which point the uploader will break. Actually, on systems affected by this issue time.time() will go negative so it won't even crash or anything, just go crazy.)
