### PR TITLE
Latitude, Longitude, Time, Base64 validation

### DIFF
--- a/couchdb/schemas/listener_telemetry.json
+++ b/couchdb/schemas/listener_telemetry.json
@@ -58,12 +58,16 @@
                     "title": "Listener Latitude",
                     "description": "The listener's current latitude, in decimal degrees.",
                     "type": "number",
+                    "minimum": -90,
+                    "maximum": 90,
                     "required": true
                 },
                 "longitude": {
                     "title": "Listener Longitude",
                     "description": "The listener's current longitude, in decimal degrees.",
                     "type": "number",
+                    "minimum": -180,
+                    "maximum": 180,
                     "required": true
                 },
                 "altitude": {

--- a/couchdb/schemas/payload_telemetry.json
+++ b/couchdb/schemas/payload_telemetry.json
@@ -37,6 +37,7 @@
                     "title": "Raw Data",
                     "description": "The raw transmitted data, as a base64 string. Must be uploaded by listeners.",
                     "type": "string",
+                    "format": "base64",
                     "required": false
                 },
                 "_string": {
@@ -84,6 +85,41 @@
                             "required": false
                         }
                     }
+                },
+                "sentence_id": {
+                    "title": "Sentence ID",
+                    "description": "The sentence ID. Used to be known as 'sequence' or 'count'. Inserted by the parser, if configured to do so.",
+                    "type": "number",
+                    "required": false
+                },
+                "time": {
+                    "title": "GPS Time",
+                    "description": "The GPS time; a string in the format of HH:MM:SS. Inserted by the parser, if configured to do so.",
+                    "type": "string",
+                    "format": "time",
+                    "required": false
+                },
+                "latitude": {
+                    "title": "Latitude",
+                    "description": "The latitude of the payload. Inserted by the parser, if configured to do so.",
+                    "type": "number",
+                    "minimum": -90,
+                    "maximum": 90,
+                    "required": false
+                },
+                "longitude": {
+                    "title": "Longitude",
+                    "description": "The longitude of the payload. Inserted by the parser, if configured to do so.",
+                    "type": "number",
+                    "minimum": -180,
+                    "maximum": 180,
+                    "required": false
+                },
+                "altitude": {
+                    "title": "Altitude",
+                    "description": "The altitude of the payload. Inserted by the parser, if configured to do so.",
+                    "type": "number",
+                    "required": false
                 }
             }
         },

--- a/habitat/sensors/stdtelem.py
+++ b/habitat/sensors/stdtelem.py
@@ -65,7 +65,7 @@ def coordinate(config, data):
 
     left, right = coordinate_format.split(".")
     if left[-1] == "d" and right[-1] == "d":
-        return float(data)
+        coord = float(data)
     elif left[0] == "d" and left[-1] == "m" and right[-1] == "m":
         first, second = data.split(".")
         degrees = float(first[:-2])
@@ -75,6 +75,15 @@ def coordinate(config, data):
         m_to_d = minutes / 60.0
         degrees += math.copysign(m_to_d, degrees)
         dp = len(second) + 3 # num digits in minutes + 1
-        return round(degrees, dp)
+        coord = round(degrees, dp)
     else:
         raise ValueError("Invalid coordinate format")
+
+    if 'name' in config and config['name'] == 'latitude':
+        if not (-90.0 <= coord <= 90.0):
+            raise ValueError("Coordinate out of range (-90 <= x <= 90)")
+    else:
+        if not (-180.0 <= coord <= 180.0):
+            raise ValueError("Coordinate out of range (-180 <= x <= 180)")
+
+    return coord

--- a/habitat/tests/test_sensors/test_stdtelem.py
+++ b/habitat/tests/test_sensors/test_stdtelem.py
@@ -82,8 +82,17 @@ class TestStdtelem:
     def test_invalid_coordinates(self):
         invalid_coordinates = [
             ("dd.dddd", "asdf"),
+            ("dd.dddd", "-200.00"),
+            ("dd.dddd", "+200.00"),
+            ("ddmm.mm", "20000.0000"),
+            ("ddmm.mm", "-20000.0000"),
             ("ddmm.mm", "03599.1234"),
             ("ddmm.mm", "-12")
         ]
         for i in invalid_coordinates:
             self.check_invalid_coordinate(i)
+
+    @raises(ValueError)
+    def test_latitude_range(self):
+        config = {"name": "latitude", "format": "dd.dddd"}
+        stdtelem.coordinate(config, "100.00")

--- a/habitat/tests/test_uploader.py
+++ b/habitat/tests/test_uploader.py
@@ -360,12 +360,17 @@ class TestUploader(object):
         self.mocker.VerifyAll()
 
     def test_uploaded_docs_pass_validation(self):
+        ptlm_with_id = copy.deepcopy(payload_telemetry_doc)
+        ptlm_with_id['_id'] = payload_telemetry_doc_id
+
         for doc in [telemetry_doc, telemetry_time_doc,
-                    info_doc, info_time_doc, payload_telemetry_doc]:
+                    info_doc, info_time_doc, ptlm_with_id]:
             validate_all(doc)
 
-        validate_all(payload_telemetry_doc_merged,
-                     payload_telemetry_doc_existing)
+        ptlm_with_id_merged = copy.deepcopy(payload_telemetry_doc_merged)
+        ptlm_with_id_merged['_id'] = payload_telemetry_doc_id
+
+        validate_all(ptlm_with_id_merged, payload_telemetry_doc_existing)
 
     def test_flights(self):
         uploader.time.time().AndReturn(1300001912.2143)

--- a/habitat/tests/test_views/test_payload_telemetry.py
+++ b/habitat/tests/test_views/test_payload_telemetry.py
@@ -30,9 +30,10 @@ from nose.tools import assert_raises
 import mox
 
 doc = {
+    "_id": "54e9ac9ec19a57d6828a737525e3cc792743a16344b1c69dfe1562620b0fac9b",
     "type": "payload_telemetry",
     "data": {
-        "_raw": "ABCDEF"
+        "_raw": "ABCDEF=="
     },
     "receivers": {
         "M0RND": {
@@ -90,6 +91,14 @@ class TestPayloadTelemetry(object):
     def test_new_docs_may_only_have_raw(self):
         mydoc = deepcopy(doc)
         mydoc['data']['result'] = 42
+        assert_raises(ForbiddenError, payload_telemetry.validate,
+                mydoc, {}, {'roles': []}, {})
+
+    def test_doc_id_must_be_sha256_of_base64_raw(self):
+        mydoc = deepcopy(doc)
+        payload_telemetry.validate(doc, {}, {'roles': []}, {})
+        mydoc["_id"] = "9e40534c92adfdd55620e786a2b434d3" + \
+                       "ffda21cae75b9c2e719853e94fbae3eb"
         assert_raises(ForbiddenError, payload_telemetry.validate,
                 mydoc, {}, {'roles': []}, {})
 

--- a/habitat/views/payload_telemetry.py
+++ b/habitat/views/payload_telemetry.py
@@ -21,6 +21,7 @@ Contains schema validation and a view by flight, payload and received time.
 """
 
 import math
+import hashlib
 from couch_named_python import ForbiddenError, UnauthorizedError, version
 from ..utils.rfc3339 import rfc3339_to_timestamp
 from .utils import validate_doc, read_json_schema
@@ -65,6 +66,10 @@ def validate(new, old, userctx, secobj):
 
     if '_admin' in userctx['roles']:
         return
+
+    expect_id = hashlib.sha256(new['data']['_raw']).hexdigest()
+    if '_id' not in new or new['_id'] != expect_id:
+        raise ForbiddenError("Document ID must be sha256(base64 _raw data)")
 
     if old:
         if new['data'] != old['data'] and 'parser' not in userctx['roles']:


### PR DESCRIPTION
- sentence_id, time, latitude, longitude, altitude types on payload_telemetry (number, string, number, number, number)
- latitude, longitude ranges on payload telemetry and listener telemetry (flight docs already checked)
- time format on payload telemetry
- _raw base64 format on payload_telemetry
- _id value on payload_telemetry
