### PR TITLE
Schema additions: payload, chase

### DIFF
--- a/couchdb/schemas/listener_telemetry.json
+++ b/couchdb/schemas/listener_telemetry.json
@@ -75,6 +75,12 @@
                     "description": "The listener's current altitude, in metres above sea level.",
                     "type": "number",
                     "required": false
+                },
+                "chase": {
+                    "title": "Mobile listener flag",
+                    "description": "An optional hint on how to display this listener's telemetry on a map.",
+                    "type": "boolean",
+                    "required": false
                 }
             }
         }

--- a/couchdb/schemas/payload_telemetry.json
+++ b/couchdb/schemas/payload_telemetry.json
@@ -86,6 +86,12 @@
                         }
                     }
                 },
+                "payload": {
+                    "title": "Payload Callsign",
+                    "description": "The callsign of the payload. Inserted by the parser.",
+                    "type": "number",
+                    "required": false
+                },
                 "sentence_id": {
                     "title": "Sentence ID",
                     "description": "The sentence ID. Used to be known as 'sequence' or 'count'. Inserted by the parser, if configured to do so.",


### PR DESCRIPTION
Document two fields in the schema; doesn't change anything for validation.

The chase key is a new one I just added to dl-fldigi. Currently the spacenearus uploader has "if "chase" in callsign.lower()" to work this out. This would probably be a better idea; though other/better suggestions are welcome.
