### PR TITLE
Parser payload_configuration search tweaks

### DIFF
--- a/habitat/parser.py
+++ b/habitat/parser.py
@@ -262,11 +262,13 @@ class Parser(object):
                         "payload_configuration": flight["value"]
                     }
 
-        config = self.db.view("payload_configuration/callsign_time_created",
-                              startkey=[callsign], include_docs=True, limit=1
-                              ).first()
+        config = self.db.view(
+            "payload_configuration/callsign_time_created_index",
+            startkey=[callsign, "inf"], include_docs=True, limit=1,
+            descending=True
+            ).first()
         # Note that we check the callsign is in this doc as if no configuration
-        # has this callsign, the firt document returned above will be for the
+        # has this callsign, the first document returned above will be for the
         # closest callsign alphabetically (and thus not useful).
         if config and self._callsign_in_config(callsign, config["doc"]):
             return {


### PR DESCRIPTION
- Need to sort descending, so that the latest version of the
  payload_configuration document is chosen (rather than the oldest)
- Add test for flight start time check (it already passes) because it
  caught my eye.
