### PR TITLE
Email errors and exceptions to us. Closes #197

### DIFF
--- a/habitat.yml
+++ b/habitat.yml
@@ -1,7 +1,14 @@
 couch_uri: "http://localhost:5984"
 couch_db: habitat
-log_stderr_level: DEBUG
-log_file_level: NONE
+log_levels:
+    stderr: DEBUG
+    file: NONE
+    email: ERROR
+log_emails:
+    to:
+        - "daniel@kraken.habhub.org"
+        - "adam@kraken.habhub.org"
+    from: "habitat@kraken.habhub.org"
 parserdaemon:
     log_file:
 parser:

--- a/habitat.yml
+++ b/habitat.yml
@@ -9,6 +9,7 @@ log_emails:
         - "daniel@kraken.habhub.org"
         - "adam@kraken.habhub.org"
     from: "habitat@kraken.habhub.org"
+    server: localhost
 parserdaemon:
     log_file:
 parser:

--- a/habitat/tests/test_utils/test_startup.py
+++ b/habitat/tests/test_utils/test_startup.py
@@ -1,4 +1,4 @@
-# Copyright 2011 (C) Daniel Richman
+# Copyright 2012 (C) Daniel Richman
 #
 # This file is part of habitat.
 #
@@ -17,9 +17,268 @@
 
 """
 Tests for habitat.utils.startup
-
-There are no tests here, since it's probably not useful to have them.
-Tests for the startup functions would largely just be the startup functions
-re-written with Mox, as they just call other modules rather than do
-anything really useful themselves.
 """
+
+import sys
+import tempfile
+import mox
+import smtplib
+import copy
+import logging
+import os
+import os.path
+
+from ...utils import startup
+
+_example_yaml = \
+"""d: 4
+blah: moo
+o:
+    listy:
+       - 2
+       - cow"""
+
+_example_parsed = {"d": 4, "blah": "moo", "o": {"listy": [2, "cow"]}}
+
+class TestLoadConfig(object):
+    def setup(self):
+        self.config = tempfile.NamedTemporaryFile()
+        self.old_argv = sys.argv
+        sys.argv = ["bin/something", self.config.name]
+
+    def teardown(self):
+        sys.argv = self.old_argv
+        self.config.close()
+
+    def test_works(self):
+        self.config.write(_example_yaml)
+        self.config.flush()
+        assert startup.load_config() == _example_parsed
+
+_logging_config = {
+    "log_levels": {},
+    "log_emails": {"to": ["addr_1", "addr_2"], "from": "from_bob",
+                   "server": "email_server"},
+    "mydaemon": {"log_file": "somewhere"}
+}
+
+class EqIfIn(mox.Comparator):
+    """
+    A mox comparator that is 'equal' to something if each of the provided
+    arguments to the constructor is 'in' (as in python operator in) the
+    right hand side of the equality
+    """
+    def __init__(self, *objs):
+        self._objs = objs
+    def equals(self, rhs):
+        for obj in self._objs:
+            if obj not in rhs:
+                return False
+        return True
+    def __repr__(self):
+        return "EqIfIn({0})".format(self._objs)
+
+class TestSetupLogging(object):
+    # Rationale for weird tests:
+    # Mocking out the handlers and loggers would be a bit silly, since it
+    # would just be rewriting startup.py line for line with mox. So these,
+    # while a little dodgy in places, actually serve to test something.
+
+    def setup(self):
+        self.mocker = mox.Mox()
+        self.config = copy.deepcopy(_logging_config)
+
+        self.old_handlers = logging.root.handlers
+        # nose creates its own handler
+        logging.root.handlers = []
+
+        # manual cleanup needed for check_file's tests
+        self.temp_dir = None
+        self.temp_files = []
+
+    def teardown(self):
+        self.mocker.UnsetStubs()
+
+        # Reset logging
+        for h in logging.root.handlers:
+            h.close()
+        logging.root.handlers = self.old_handlers
+
+        if self.temp_files:
+            for f in self.temp_files:
+                try:
+                    os.unlink(f)
+                except:
+                    pass
+
+        if self.temp_dir:
+            os.rmdir(self.temp_dir)
+
+    def generate_log_messages(self):
+        l = logging.getLogger("test_source")
+        l.debug("Debug message TEST1")
+        l.info("Info message TEST2")
+        l.warning("Warning message TEST3")
+        l.error("Error message TEST4")
+        l.critical("Error message TEST5")
+        def function_TEST6():
+            raise ValueError("TEST7")
+        try:
+            function_TEST6()
+        except:
+            l.exception("Exception TEST8")
+
+    def expected_messages(self, level, initialised=True):
+        """
+        returns, for each expected message, a tuple of strings that should
+        be found in that message
+        """
+        if level <= logging.INFO and initialised:
+            yield "Log initialised",
+        if level <= logging.DEBUG:
+            yield "TEST1",
+        if level <= logging.INFO:
+            yield "TEST2",
+        if level <= logging.WARNING:
+            yield "TEST3",
+        if level <= logging.ERROR:
+            yield "TEST4",
+        if level <= logging.CRITICAL:
+            yield "TEST5",
+        if level <= logging.ERROR:
+            # message must contain function name, exception arg, log msg
+            yield "TEST6", "TEST7", "TEST8"
+
+    levels = \
+        [logging.CRITICAL, logging.ERROR, logging.WARNING,
+         logging.INFO, logging.DEBUG]
+    level_names = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
+
+    checks = zip(levels, level_names)
+
+    def test_stderr(self):
+        for a, b in self.checks:
+            yield self.check_stderr, a, b
+
+    def test_file(self):
+        for a, b in self.checks:
+            yield self.check_file, a, b
+
+    def test_email(self):
+        for a, b in self.checks:
+            yield self.check_email, a, b
+
+    def check_stderr(self, level, level_name):
+        self.config["log_levels"]["stderr"] = level_name
+
+        self.mocker.StubOutWithMock(sys, 'stdout')
+        self.mocker.StubOutWithMock(sys, 'stderr')
+
+        for things in self.expected_messages(level):
+            sys.stderr.write(EqIfIn(*things))
+            sys.stderr.flush()
+
+        self.mocker.ReplayAll()
+
+        startup.setup_logging(self.config, "mydaemon")
+        self.generate_log_messages()
+
+        self.mocker.VerifyAll()
+
+    def check_file(self, level, level_name):
+        # Mocks not used.
+        self.mocker.ReplayAll()
+
+        self.temp_dir = tempfile.mkdtemp()
+        filename_a = os.path.join(self.temp_dir, "log_a")
+        filename_b = os.path.join(self.temp_dir, "log_b")
+        self.temp_files = [filename_a, filename_b]
+
+        self.config["log_levels"]["file"] = level_name
+        self.config["mydaemon"]["log_file"] = filename_a
+
+        startup.setup_logging(self.config, "mydaemon")
+        self.generate_log_messages()
+        logging.getLogger("tests").critical("This should be in file b")
+
+        # WatchedFileHandler, so should be able to move log file and it will
+        # automatically write to new file at old name.
+        os.rename(filename_a, filename_b)
+        self.generate_log_messages()
+        logging.getLogger("tests").critical("This should be in file a")
+
+        # N.B.: It should flush after each message, so no need to close/flush
+        with open(filename_a) as f:
+            data_a = f.read()
+        with open(filename_b) as f:
+            data_b = f.read()
+
+        for things in self.expected_messages(level, initialised=False):
+            for match in things:
+                assert match in data_a
+        for things in self.expected_messages(level):
+            for match in things:
+                assert match in data_b
+
+        assert "should be in file a" in data_a
+        assert "should be in file b" in data_b
+
+        self.mocker.VerifyAll()
+
+    def check_email(self, level, level_name):
+        self.config["log_levels"]["email"] = level_name
+
+        # SMTPHandler uses smtplib
+        self.mocker.StubOutClassWithMocks(smtplib, 'SMTP')
+
+        for things in self.expected_messages(level):
+            smtp = smtplib.SMTP("email_server", 25)
+            smtp.sendmail("from_bob", ["addr_1", "addr_2"], EqIfIn(*things))
+            smtp.quit()
+
+        self.mocker.ReplayAll()
+
+        startup.setup_logging(self.config, "mydaemon")
+        self.generate_log_messages()
+
+        self.mocker.VerifyAll()
+
+    def test_silent(self):
+        self.mocker.StubOutWithMock(sys, 'stdout')
+        self.mocker.StubOutWithMock(sys, 'stderr')
+        # No output on std{err,out}
+
+        self.mocker.ReplayAll()
+
+        startup.setup_logging(self.config, "mydaemon")
+        self.generate_log_messages()
+
+        self.mocker.VerifyAll()
+
+class TestMain(object):
+    def setup(self):
+        self.mocker = mox.Mox()
+
+    def teardown(self):
+        self.mocker.UnsetStubs()
+
+    def test_works(self):
+        self.mocker.StubOutWithMock(startup, 'load_config')
+        self.mocker.StubOutWithMock(startup, 'setup_logging')
+
+        main_class = self.mocker.CreateMockAnything()
+        main_class.__name__ = "ExampleDaemon"
+
+        main_object = self.mocker.CreateMockAnything()
+
+        startup.load_config().AndReturn({"the_config": True})
+        startup.setup_logging({"the_config": True}, "exampledaemon")
+        main_class({"the_config": True}, "exampledaemon")\
+                .AndReturn(main_object)
+        main_object.run()
+
+        self.mocker.ReplayAll()
+
+        startup.main(main_class)
+
+        self.mocker.VerifyAll()

--- a/habitat/tests/test_views/test_flight.py
+++ b/habitat/tests/test_views/test_flight.py
@@ -176,5 +176,4 @@ class TestFlight(object):
     def test_view_name(self):
         mydoc = deepcopy(doc)
         result = list(flight.all_name_map(mydoc))
-        print result
         assert result == [("Test Launch", None)]

--- a/habitat/utils/startup.py
+++ b/habitat/utils/startup.py
@@ -47,11 +47,8 @@ def load_config():
     return config
 
 
-def _get_logging_level(config, key):
-    if key not in config:
-        return None
-
-    value = config[key].upper()
+def _get_logging_level(value):
+    value = value.upper()
 
     if value == "NONE":
         return None
@@ -64,6 +61,20 @@ class null_logger(logging.Handler):
     pass
 
 
+_format_email = \
+"""%(levelname)s from logger %(name)s (thread %(threadName)s)
+
+Time:       %(asctime)s
+Location:   %(pathname)s:%(lineno)d
+Module:     %(module)s
+Function:   %(funcName)s
+
+%(message)s"""
+
+_format_string = \
+"[%(asctime)s] %(levelname)s %(name)s %(threadName)s: %(message)s"
+
+
 def setup_logging(config, daemon_name):
     """
     **setup_logging** initalises the :py:mod:`Python logging module <logging>`.
@@ -72,9 +83,6 @@ def setup_logging(config, daemon_name):
     Handlers, depending on the values provided for ``log_file_level`` and
     ``log_stderr_level`` in *config*.
     """
-
-    formatstring = "[%(asctime)s] %(levelname)s %(name)s %(threadName)s: " + \
-                   "%(message)s"
 
     root_logger = logging.getLogger()
 
@@ -86,12 +94,15 @@ def setup_logging(config, daemon_name):
     logging.getLogger("restkit").setLevel(logging.WARNING)
 
     have_handlers = False
-    stderr_level = _get_logging_level(config, "log_stderr_level")
-    file_level = _get_logging_level(config, "log_file_level")
+    levels = config["log_levels"]
+
+    stderr_level = _get_logging_level(levels.get("stderr", "NONE"))
+    file_level = _get_logging_level(levels.get("file", "NONE"))
+    email_level = _get_logging_level(levels.get("email", "NONE"))
 
     if stderr_level != None:
         stderr_handler = logging.StreamHandler()
-        stderr_handler.setFormatter(logging.Formatter(formatstring))
+        stderr_handler.setFormatter(logging.Formatter(_format_string))
         stderr_handler.setLevel(stderr_level)
         root_logger.addHandler(stderr_handler)
         have_handlers = True
@@ -99,9 +110,23 @@ def setup_logging(config, daemon_name):
     if file_level != None:
         file_name = config[daemon_name]["log_file"]
         file_handler = logging.handlers.WatchedFileHandler(file_name)
-        file_handler.setFormatter(logging.Formatter(formatstring))
+        file_handler.setFormatter(logging.Formatter(_format_string))
         file_handler.setLevel(file_level)
         root_logger.addHandler(file_handler)
+        have_handlers = True
+
+    if email_level != None:
+        emails_to = config["log_emails"]["to"]
+        emails_from = config["log_emails"]["from"]
+        email_server = config["log_emails"]["server"]
+        if not isinstance(emails_to, list):
+            emails_to = [emails_to]
+
+        mail_handler = logging.handlers.SMTPHandler(
+                email_server, emails_from, emails_to, daemon_name)
+        mail_handler.setLevel(logging.ERROR)
+        mail_handler.setFormatter(logging.Formatter(_format_email))
+        root_logger.addHandler(mail_handler)
         have_handlers = True
 
     if not have_handlers:

--- a/habitat/utils/startup.py
+++ b/habitat/utils/startup.py
@@ -58,7 +58,8 @@ def _get_logging_level(value):
 
 class null_logger(logging.Handler):
     """A python logging handler that discards log messages silently."""
-    pass
+    def emit(self, record):
+        pass
 
 
 _format_email = \
@@ -124,7 +125,7 @@ def setup_logging(config, daemon_name):
 
         mail_handler = logging.handlers.SMTPHandler(
                 email_server, emails_from, emails_to, daemon_name)
-        mail_handler.setLevel(logging.ERROR)
+        mail_handler.setLevel(email_level)
         mail_handler.setFormatter(logging.Formatter(_format_email))
         root_logger.addHandler(mail_handler)
         have_handlers = True
@@ -134,7 +135,7 @@ def setup_logging(config, daemon_name):
         # If we're meant to be totally silent...
         root_logger.addHandler(null_logger())
 
-    logger.info("Log initalised")
+    logger.info("Log initialised")
 
 
 def main(main_class):


### PR DESCRIPTION
Doesn't close the "also good would be a supervisord event listener" bit of #197

N.B.: Changes to the layout of habitat.yml will require care when deploying.

test_startup.py unit tests are of questionable quality at best.

I believe that testing by stubbing out and mocking logger.Handler, logging.Logger, e.t.c., would be pointless (and is the reason so far startup hasn't had any tests) since it would just be a re-write of startup.py, but speaking mox. Instead of actual bugs we would then just have 'bugs' where the mocks we write don't behave the same as the real thing. Therefore, these tests mock input/output streams/emails and check written files to ensure that it sets up habitat logging correctly. I think (?) this is OK, though you might want to check it a bit more closely.
