### PR TITLE
APRS Daemon

### DIFF
--- a/bin/aprs_importer
+++ b/bin/aprs_importer
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# Copyright 2011 (C) Daniel Richman
+#
+# This file is part of habitat.
+#
+# habitat is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# habitat is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with habitat.  If not, see <http://www.gnu.org/licenses/>.
+import sys
+sys.path.insert(0, '/home/rgp/dev/habitat')
+
+try:
+    import habitat
+except ImportError:
+    # Find habitat, assuming we're in the habitat git repo.
+    import sys
+    from os.path import abspath, split, join
+    sys.path.append(join(split(abspath(__file__))[0], '..'))
+    import habitat
+
+from habitat.aprs_daemon import APRSDaemon
+from habitat.utils.startup import main
+main(APRSDaemon)

--- a/habitat.yml
+++ b/habitat.yml
@@ -12,6 +12,11 @@ log_emails:
     server: localhost
 parserdaemon:
     log_file:
+aprsdaemon:
+    api_key: ""
+    flight_check_interval: 300
+    aprs_pull_interval: 30
+    log_file:
 parser:
     certs_dir: "certs"
     modules:

--- a/habitat.yml
+++ b/habitat.yml
@@ -1,9 +1,9 @@
-couch_uri: "http://localhost:5984"
+couch_uri: "http://beta.habitat.habhub.org"
 couch_db: habitat
 log_levels:
     stderr: DEBUG
     file: NONE
-    email: ERROR
+    email: NONE
 log_emails:
     to:
         - "daniel@kraken.habhub.org"
@@ -13,7 +13,11 @@ log_emails:
 parserdaemon:
     log_file:
 aprsdaemon:
-    api_key: ""
+    server: "first.aprs.net"
+    port: 14580
+    login:
+        callsign: ""
+        password: ""
     flight_check_interval: 300
     aprs_pull_interval: 30
     log_file:

--- a/habitat.yml
+++ b/habitat.yml
@@ -19,7 +19,6 @@ aprsdaemon:
         callsign: ""
         password: ""
     flight_check_interval: 300
-    aprs_pull_interval: 30
     log_file:
 parser:
     certs_dir: "certs"

--- a/habitat/__init__.py
+++ b/habitat/__init__.py
@@ -37,6 +37,7 @@ See http://habitat.habhub.org for more information.
     habitat.uploader
     habitat.utils
     habitat.views
+    habitat.aprs_daemon
 """
 
 __name__ = "habitat"
@@ -54,3 +55,4 @@ from . import sensors
 from . import uploader
 from . import utils
 from . import views
+from . import aprs_daemon

--- a/habitat/aprs.py
+++ b/habitat/aprs.py
@@ -1,0 +1,457 @@
+# Copyright 2013 (C) Rossen Georgiev
+#
+# This file is part of habitat.
+#
+# habitat is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# habitat is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with habitat.  If not, see <http://www.gnu.org/licenses/>.
+
+import socket
+import time
+import datetime
+import re
+import math
+import logging
+import statsd
+
+logger = logging.getLogger("habitat.aprs")
+statsd.init_statsd({'STATSD_BUCKET_PREFIX': 'habitat'})
+
+__all__ = ['APRS', 'APRSModule']
+
+class aprs:
+    def __init__(self, host, port, callsign, passwd):
+        """
+        APRS module that listens and parses sentences passed by aprs.net servers
+        """
+
+        self.set_server(host, port)
+        self.set_login(callsign, passwd)
+
+        self.sock = None
+        self.filter = "b/" # empty bud filter
+
+        self._connected = False;
+
+    def callsign_filter(self, callsigns):
+        """
+        Sets a filter for the specified callsigns. Only those will be send to us by the server
+        """
+
+        if type(callsigns) is not list or len(callsigns) == 0:
+            return False
+
+        self.filter = "b/%s" % "/".join(callsigns)
+
+        logger.debug("Setting filter to: %s" % self.filter)
+
+        if self._connected:
+            self.sock.sendall("#filter %s\r\n" % self.filter)
+
+        return True
+
+    def set_login(self, callsign, passwd):
+        """
+        Set callsign and password
+        """
+        self.callsign = callsign
+        self.passwd = passwd
+
+    def set_server(self, host, port=14850):
+        """
+        Set server ip/host and port to use
+        """
+        self.server = (host, port)
+
+    def connect(self, **kwargs):
+        """
+        Initiate connection to APRS server and attempt to login
+        """
+
+        blocking = False  # when true, func wont return until connection is established
+
+        if kwargs.has_key('blocking'):
+            blocking = kwargs['blocking']
+
+        if not self._connected:
+            logger.debug("Attempting connection to %s:%s" % (self.server[0], self.server[1]))
+            self._connect(blocking)
+            logger.debug("Sending login information")
+            self._send_login()
+            logger.debug("Login successful")
+
+    def close(self):
+        """
+        Closes the socket
+        Called internally when Exceptions are raised
+        """
+
+        self._connected = False
+
+        if self.sock is not None:
+            self.sock.close()
+
+
+    def consumer(self, callback, **kwargs):
+        """
+        When a position sentence is recieved, it will be passed to the callback function
+        """
+        blocking = True    # customer runs forever, when false, the cunsumer will return to resume program flow
+        immortal = False   # when true, consumer will try to reconnect and stop propagation of Exceptions
+        raw = False        # when true, pass raw aprs sentence to callback, otherwise pass parsed data as dict
+
+        for key, value in kwargs.iteritems():
+            if key == 'blocking':
+                blocking = value
+            elif key == 'immortal':
+                immortal = value
+            elif key == 'raw':
+                raw = value
+
+        if not self._connected:
+            raise ConnectionError("not connected to a server")
+
+        while True:
+            try:
+                for line in self._socket_readlines(blocking):
+                    if line[0] != "#":
+                        if raw:
+                            callback(line)
+                        else:
+                            callback(self._parse(line))
+                    #else:
+                    #     print "Server: %s" % line
+            except KeyboardInterrupt:
+                raise
+            except (ConnectionDrop, ConnectionError):
+                self.close()
+
+                if not immortal:
+                    raise
+                else:
+                    self.connect(blocking=blocking)
+                    continue
+            except:
+                if not immortal:
+                    raise
+                continue
+
+            if not blocking:
+                break
+
+
+    def _connect(self, blocking=False):
+        """
+        Attemps to open a connection to the server, retrys if it fails
+        """
+
+        while True:
+            try:
+                self.sock = socket.create_connection(self.server, 15) # 15 seconds connection timeout
+                self.sock.settimeout(5) # 5 second timeout to recieve server banner
+
+                if self.sock.recv(512)[0] != "#":
+                    raise ConnectionError("invalid banner from server")
+
+                self.sock.setblocking(True)
+
+                break;
+            except Exception, e:
+                if e == "timed out":
+                    raise ConnectionError("no banner from server")
+                elif not blocking:
+                    raise ConnectionError(e)
+
+                time.sleep(30) # attempt to reconnect after 30 seconds
+
+        self._connected = True
+
+    def _send_login(self):
+        """
+        Sends login string to server
+        """
+        login_str = "user {0} pass {1} vers habitat-daemon 0.1 filter {2}\r\n".format(self.callsign, self.passwd, self.filter)
+
+
+        try:
+            self.sock.sendall(login_str)
+            self.sock.settimeout(5)
+            test = self.sock.recv(len(login_str) + 100)
+            self.sock.setblocking(True)
+
+            (x, x, callsign, status, x) =  test.split(' ',4)
+
+            if callsign != self.callsign:
+                raise LoginError("login callsign does not match")
+            if status != "verified,":
+                raise LoginError("callsign is not 'verified'")
+
+        except LoginError, e:
+            self.close()
+            raise LoginError("failed to login: %s" % e)
+        except:
+            self.close()
+            raise LoginError("failed to login")
+
+    def _socket_readlines(self, blocking=False):
+        """
+        Generator for complete lines, recieved from the server
+        """
+
+        try:
+            self.sock.setblocking(False)
+        except socket.error, e:
+            raise ConnectionDrop("connection dropped")
+
+        buf = ''
+
+        while True:
+            short_buf = ''
+
+            try:
+                short_buf = self.sock.recv(128)
+            except socket.error, e:
+                if "Resource temporarily unavailable" in e:
+                    if blocking:
+                        time.sleep(0.5)
+                        continue
+                    else:
+                        if len(buf) == 0:
+                            break;
+                raise
+
+            # sock.recv returns empty if the connection drops
+            if not short_buf:
+                raise ConnectionDrop("connection dropped")
+
+            buf += short_buf
+
+            if "\r\n" in buf:
+                (line, buf) = buf.split("\r\n", 1)
+                yield line
+
+    def _parse(self, raw_sentence):
+        """
+        Parses position sentences and returns a dict with the useful data
+        All attributes are in meteric units
+
+        Supported formats:
+            FIXED:
+                .......!DDMM.hhN/DDDMM.hhW$comments...   (fixed short format)
+                       =DDMM.hhN/DDDMM.hhW$comments      (message capable)
+                /DDHHMM/DDMM.hhN/DDDMM.hhW$comments...   (no APRS is running)
+            MOBILE:
+                @DDHHMM/DDMM.hhN/DDDMM.hhW$CSE/SPD/comments...
+            DF:
+                @DDHHMM/DDMM.hhN/DDDMM.hhWCSE/SPD/BRG/NRQ/Comments
+                .......z............................. (indicates Zulu date-time)
+                ......./............................. (indicates LOCAL date-time)
+                .......h............................. (Zulu time in hhmmss)
+
+            NMAE: (NOT SUPPORTED)
+                $GPRMC,151447,A,4034.5189,N,10424.4955,W,6.474,132.5,220406,10.1,E*58
+
+                    1  Time Stamp
+                    2  validity - A-ok, V-invalid
+                    3  current Latitude
+                    4  North/South
+                    5  current Longitude
+                    6  East/West
+                    7  Speed in knots
+                    8  True course
+                    9  Date Stamp
+                    10 Variation
+                    11 East/West
+                    12 checksum
+
+                $GPGGA,151449,4034.5163,N,10424.4937,W,1,06,1.41,21475.8,M,-21.8,M,,*4D
+
+                    1  UTC of Position
+                    2  Latitude
+                    3  N or S
+                    4  Longitude
+                    5  E or W
+                    6  GPS quality indicator (0=invalid; 1=GPS fix; 2=Diff. GPS fix)
+                    7  Number of satellites in use [not those in view]
+                    8  Horizontal dilution of position
+                    9  Antenna altitude above/below mean sea level (geoid)
+                    10 Meters  (Antenna height unit)
+                    11 Geoidal separation (Diff. between WGS-84 earth ellipsoid and
+                       mean sea level.  -=geoid is below WGS-84 ellipsoid)
+                    12 Meters  (Units of geoidal separation)
+                    13 Age in seconds since last update from diff. reference station
+                    14 Diff. reference station ID#
+                    15 Checksum
+
+            uBlox: (NOT SUPPORTED)
+                 $PUBX,00,081350.00,4717.113210,N,00833.915187,E,546.589,G3,2.1,2.0,0.007,77.52,0.007,,0.92,1.19,0.77,9,0,0*5F
+                 $PUBX,00,hhmmss.ss,Latitude,N,Longitude,E,AltRef,NavStat,Hacc,Vacc,SOG,COG,Vvel,+ageC,HDOP,VDOP,TDOP,GU,RU,DR,*hh
+                 $PUBX,01,hhmmss.ss,Easting,E,Northing,N,AltMSL,NavStat,Hacc,Vacc,SOG,COG,Vvel,ag+eC,HDOP,VDOP,TDOP,GU,RU,DR,*hh
+
+                    $PUBX       - Message ID, UBX protocol header, proprietary sentence
+                    00          - Propietary message identifier: 00
+                    hhmmss.ss   - UTC Time, Current time
+                    ddmm.mmmm   - Latitude, Degrees + minutes
+                    [NS]        - N/S Indicator,
+                    dddmm.mmmm  - Longitude, Degrees + minutes
+                    [EW]        - E/W Indicator,
+                    546.589     - (meters) Altitude above user datum ellipsoid.
+                    G3          - Navigation Status, See Table below
+                    2.1         - Horizontal accuracy estimate.
+                    2.0         - Vertical accuracy estimate.
+                    0.007       - Speed over ground
+                    77.52       - Course over ground
+                    0.007       - (m/s) Vertical velocity, positive=downwards
+                    -           - Age of most recent DGPS corrections, empty = none available
+                    0.92        - HDOP, Horizontal Dilution of Precision
+                    1.19        - VDOP, Vertical Dilution of Precision
+                    0.77        - TDOP, Time Dilution of Precision
+                    9           - Number of GPS satellites used in the navigation solution
+                    0           - Number of GLONASS satellites used in the navigation solution
+                    0           - DR used
+                    *5B         - Checksum
+
+                    Navigation Status
+                    -----------------
+                    NF No Fix
+                    DR Predictive Dead Reckoning Solution
+                    G2 Stand alone 2D solution
+                    G3 Stand alone 3D solution
+                    D2 Differential 2D solution
+                    D3 Differential 3D solution
+
+            Custom:
+                @DDHHMMhDDMM.hhN/DDDMM.hhWO234/038/A=001563
+
+                    course: 234 degrees
+                    speed: 38 kntos
+                    altitude: 1563 feet
+        """
+        if len(raw_sentence) is 0:
+            return False
+
+        logger.debug("Parsing: %s" % raw_sentence)
+
+        (header, body) = raw_sentence.split(':')
+        (source, path) = header.split('>')
+
+        # TODO, validate SOURCE callsign and parse path
+        # aprs.net should do that for us
+
+        parsed = { 'source': source, 'path': path.split(',') }
+
+        # attempt to parse the body
+
+        packet_type = body[0]
+        body = body[1:]
+
+        # Mic-encoded body
+        if packet_type in ("\x27","\x60"):
+            raise ParseError("packet seems to be Mic-Encoded, unable to parse", raw_sentence)
+
+        # regular or compressed
+
+        if packet_type in('!','=','/','@'):
+            if len(body) < 14:
+                raise ParseError("failed, packet is too short to be valid", raw_sentence)
+
+            # try to parse timestamp
+            ts = re.findall(r"^[0-9]{6}[hz\/]$", body[0:7])
+            form = ''
+            if ts:
+                ts = ts[0]
+                form = ts[6]
+                ts = ts[0:6]
+                utc = datetime.datetime.utcnow()
+
+                if form == 'h': # zulu hhmmss format
+                    timestamp = utc.strptime("{0} {1} {2} {3}".format(utc.year, utc.month, utc.day, ts), "%Y %m %d %H%M%S")
+                elif form == 'z': # zulu ddhhss format
+                    timestamp = utc.strptime("{0} {1} {2}".format(utc.year, utc.month, ts), "%Y %m %d%M%S")
+                else: # '/' local ddhhss format
+                    timestamp = utc.strptime("{0} {1} {2}".format(utc.year, utc.month, ts), "%Y %m %d%M%S")
+
+                parsed.update({ 'timestamp': timestamp.isoformat() })
+
+                # remove datetime from the body for further parsing
+                body = body[7:]
+
+            try:
+                (
+                lat_deg,
+                lat_min,
+                lat_dir,
+                symbol_table,
+                lon_deg,
+                lon_min,
+                lon_dir,
+                symbol,
+                comment
+                ) = re.match(r"^(\d{2})([0-7 ][0-9 ]\.[0-9 ]{2})([NnSs])(.)(\d{3})([0-7 ][0-9 ]\.[0-9 ]{2})([EeWw])([\x21-\x7b\x7d])(.*)$", body).groups()
+
+                # optional format extention - bearing, speed and altitude (feet)
+                extra = re.findall(r"^([0-9]{3})/([0-9]{3})(/A=([0-9]{6})/?)?(.*)$", comment)
+
+                if extra:
+                    (bearing, speed, empty, altitude, comment) = extra[0]
+
+                    parsed.update({ 'bearing': int(bearing), 'speed': int(speed)*0.514444 })
+                    if altitude:
+                        parsed.update({ 'altitude': int(altitude)*0.3048 })
+
+                # TODO throw exception when incorrect symbol table is selected? correct = [\/\\0-9A-Z]
+                parsed.update({ 'symbol': symbol, 'symbol_table': symbol_table })
+
+                if int(lat_deg) > 89 or int(lat_deg) < 0:
+                    raise ParseError("latitude is out of range (0-90 degrees)", raw_sentence)
+                if int(lon_deg) > 179 or int(lon_deg) < 0:
+                    raise ParseError("longitutde is out of range (0-180 degrees)", raw_sentence)
+
+                latitude = int(lat_deg) + ( float(lat_min) / 60.0 )
+                longitude = int(lon_deg) + ( float(lon_min) / 60.0 )
+
+                parsed.update({'latitude': latitude, 'longitude': longitude})
+
+            except (ValueError, AttributeError), e:
+                # failed to match normal sentence sentence
+                raise ParseError("unknown format", raw_sentence)
+
+        # once we have latitude, and we can aproximate local timezone, if we need
+        if form not in ('h','z',''):
+            timestamp = timestamp + datetime.timedelta(hours=math.floor(parsed['latitude']/7.5))
+            parsed['timestamp'] = timestamp.isoformat()
+
+        logger.debug("Parsed ok.")
+        return parsed
+
+# Exceptions
+class GenericError(Exception):
+    def __init__(self, message):
+        logger.debug("%s: %s" % (self.__class__.__name__, message))
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+class ParseError(GenericError):
+    def __init__(self, msg, packet=''):
+        GenericError.__init__(self, msg)
+        self.packet = packet
+
+class LoginError(GenericError):
+    pass
+
+class ConnectionError(GenericError):
+    pass
+
+class ConnectionDrop(ConnectionError):
+    pass

--- a/habitat/aprs_daemon.py
+++ b/habitat/aprs_daemon.py
@@ -1,0 +1,85 @@
+# Copyright 2010, 2011, 2012 (C) Adam Greig, Daniel Richman
+#
+# This file is part of habitat.
+#
+# habitat is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# habitat is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with habitat.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Run the APRS importer as a daemon watching flight docs in CouchDB
+"""
+
+import logging
+import couchdbkit
+import copy
+import statsd
+import time
+
+from .utils import immortal_changes
+
+logger = logging.getLogger("habitat.aprs_daemon")
+statsd.init_statsd({'STATSD_BUCKET_PREFIX': 'habitat'})
+
+__all__ = ['APRSDaemon']
+
+class APRSDaemon(object):
+    """
+    :class:`APRSDaemon` runs persistently, watching flight docs in CouchDB
+    and looking for flights set to use APRS. Upon which starts polling aprs.fi
+    for position data for every callsign and converting it to habitat telemetry
+    """
+
+    def __init__(self, config, daemon_name="aprsdaemon"):
+        """
+        On construction, it will:
+
+        * Connect to CouchDB using ``self.config["couch_uri"]`` and
+          ``config["couch_db"]``.
+        """
+
+        self.config = copy.deepcopy(config)
+
+        # holds { callsign : chase (bool) }, chase is true for chaser callsigns
+        self.callsigns = {}
+
+        self.couch_server = couchdbkit.Server(config["couch_uri"])
+        self.db = self.couch_server[config["couch_db"]]
+
+    def run(self):
+
+        self.fetch_active_flights()
+        print self.callsigns
+
+    def fetch_active_flights(self):
+        """
+        Pulls all active flights from habitat
+        """
+        self.callsigns = {}
+
+        for flight in self.db.view("flight/end_start_including_payloads", include_docs=True, startkey=[time.time()]).all():
+            if flight['key'][3] == 1 and flight['doc'].has_key('aprs') and len(flight['doc']['aprs']) > 0:
+                current = flight['doc']['aprs']
+
+                if current.has_key['payloads']:
+                    self.callsigns.update({cs: 0 for cs in current['payloads']})
+
+                if current.has_key['chasers']:
+                    self.callsigns.update({cs: 1 for cs in current['chasers']})
+
+    def _couch_callback(self, result):
+        """
+        Handle a new result from the CouchDB _changes feed. Passes the doc off
+        to APRS.parse, then saves the result.
+        """
+        self.last_seq = result['seq']
+        print result

--- a/habitat/views/flight.py
+++ b/habitat/views/flight.py
@@ -40,7 +40,7 @@ def validate(new, old, userctx, secobj):
     if not schema:
         schema = read_json_schema("flight.json")
     validate_doc(new, schema)
-    
+
     if '_admin' in userctx['roles']:
         return
 
@@ -83,7 +83,7 @@ def end_start_including_payloads_map(doc):
         [end_time, start_time, flight_id, 0] -> null
 
     Times are all UNIX timestamps (and therefore in UTC).
-    
+
     Sorts by flight window end time then start time.
 
     If the flight has payloads, emit it with the list of payloads, and emit
@@ -103,7 +103,7 @@ def end_start_including_payloads_map(doc):
     windows have not yet ended. Use ``include_docs=true`` to have the linked
     payload_configuration documents fetched and returned as the ``"doc"`` key
     for that row, otherwise the row's value will just contain an object that
-    holds the linked ID. See the 
+    holds the linked ID. See the
     `CouchDB documentation <http://wiki.apache.org/couchdb/Introduction_to_CouchDB_views#Linked_documents>`_
     for details on linked documents.
     """
@@ -133,13 +133,13 @@ def launch_time_including_payloads_map(doc):
         ...
 
     Or, when a flight has no payloads::
-        
+
         [launch_time, flight_id, 0] -> null
 
     Times are all UNIX timestamps (and therefore in UTC).
 
     Sort by flight launch time.
-    
+
     Only shows approved flights.
 
     Used by the calendar and other interface elements to show a list of
@@ -149,7 +149,7 @@ def launch_time_including_payloads_map(doc):
     Use ``include_docs=true`` to have the linked
     payload_configuration documents fetched and returned as the ``"doc"`` key
     for that row, otherwise the row's value will just contain an object that
-    holds the linked ID. See the 
+    holds the linked ID. See the
     `CouchDB documentation <http://wiki.apache.org/couchdb/Introduction_to_CouchDB_views#Linked_documents>`_
     for details on linked documents.
     """
@@ -176,7 +176,7 @@ def all_name_map(doc):
     Sort by flight name.
 
     Show all flights, even those unapproved.
-    
+
     Used where the UI must show all the flights in some usefully searchable
     sense, for instance when creating a new flight document based on some old
     or unapproved one, or when approving new flight documents.


### PR DESCRIPTION
I am nearly finished with the APRS daemon. Currently, a check for active flights is only performed on startup. There are a few things I need to tweak, but that is for later.

Here is what the typical output is like:

```
$ hp ~/dev/habitat/bin/aprs_importer
[2013-02-21 01:13:53,796] INFO habitat.utils.startup MainThread: Log initialised
[2013-02-21 01:13:53,861] INFO habitat.aprs_daemon MainThread: Checking for active flights
[2013-02-21 01:13:53,872] INFO habitat.aprs_daemon MainThread: 0 active flights with 1 callsigns
[2013-02-21 01:13:53,872] INFO habitat.aprs MainThread: Setting filter to: b/LZ1DEV
[2013-02-21 01:13:53,872] INFO habitat.aprs MainThread: Attempting connection to first.aprs.net:14580
[2013-02-21 01:13:54,375] INFO habitat.aprs MainThread: Sending login information
[2013-02-21 01:13:54,488] INFO habitat.aprs MainThread: Login successful
[2013-02-21 01:14:04,999] INFO habitat.aprs MainThread: Parsing: LZ1DEV>APU25N,TCPIP*,qAC,THIRD:=/8sweTCpK-  BRTL-SDR RX-only
[2013-02-21 01:14:05,001] DEBUG habitat.aprs MainThread: ParseError: unknown format
[2013-02-21 01:15:07,067] INFO habitat.aprs MainThread: Parsing: LZ1DEV>APU25N,TCPIP*,qAC,THIRD:=4241.81N/02317.93E-RTL-SDR RX-only
[2013-02-21 01:15:07,068] DEBUG habitat.aprs MainThread: Parsing as normal uncompressed format
[2013-02-21 01:15:07,068] INFO habitat.aprs MainThread: Parsed ok.
[2013-02-21 01:15:07,703] ERROR habitat.aprs_daemon MainThread: {"error":"forbidden","reason":"New documents may only have _raw in data."}
```

Uploading `listener_telemetry` for `chasers` is ok, However, when I try to create a `payload_telemetry` doc, it fails with the error above. I figure, it is because how the `parser` is designed. How can we make it work ?
