### PR TITLE
Parser doc selection logging

### DIFF
--- a/habitat/parser.py
+++ b/habitat/parser.py
@@ -183,6 +183,8 @@ class Parser(object):
         elif config:
             if "_id" not in config:
                 config["_id"] = None
+            logger.debug("payload_configuration provided (id: {0})"
+                    .format(config["_id"]))
             return {"id": config["_id"], "payload_configuration": config}
 
         config = self._find_config_doc(callsign)
@@ -192,6 +194,14 @@ class Parser(object):
                          .format(callsign=callsign))
             statsd.increment("parser.no_config_doc")
             raise CantGetConfig()
+
+        if "flight_id" in config:
+            logger.debug("Selected payload_configuration {0} from flight {1} "
+                         "for {2!r}"
+                    .format(config["id"], config["flight_id"], callsign))
+        else:
+            logger.debug("Selected payload_configuration {0} for {1!r}"
+                    .format(config["id"], callsign))
 
         return config
 


### PR DESCRIPTION
Two changes:

I noticed that if a parse succeeds you can see the config document used in the log via the `DEBUG habitat.parser MainThread: Parsed data: {` line, but it's not shown for failed parses. The second commit adds that.

I wanted to quickly check the logging output so looked for something that tested _get_config  without a provided config - couldn't find it, so added it. It was tested already (indirectly) by test_parse, but I figured since some of the other tests mock _get_config out, why not
