### PR TITLE
Require most strings be non-empty

### DIFF
--- a/couchdb/schemas/flight.json
+++ b/couchdb/schemas/flight.json
@@ -8,11 +8,13 @@
         "_id": {
             "title": "CouchDB Document ID",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_rev": {
             "title": "CouchDB Document Revision Number",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_revisions": {
@@ -51,6 +53,7 @@
             "title": "Launch Name",
             "description": "A human-readable name to refer to this launch by.",
             "type": "string",
+            "minLength": 1,
             "required": true
         },
         "launch": {
@@ -118,18 +121,21 @@
                     "title": "Launch Location",
                     "description": "Optional human-readable string for launch location, e.g., a city name.",
                     "type": "string",
+                    "minLength": 1,
                     "required": false
                 },
                 "project": {
                     "title": "Project",
                     "description": "The project name that this launch is associated with.",
                     "type": "string",
+                    "minLength": 1,
                     "required": false
                 },
                 "group": {
                     "title": "Group",
                     "description": "The group(s) responsible for this flight.",
                     "type": "string",
+                    "minLength": 1,
                     "required": false
                 }
             }
@@ -141,7 +147,8 @@
             "items": {
                 "title": "Payload Configuration ID",
                 "description": "The CouchDB Document ID for a payload configuration of a payload in this flight.",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "aprs": {

--- a/couchdb/schemas/listener_information.json
+++ b/couchdb/schemas/listener_information.json
@@ -8,11 +8,13 @@
         "_id": {
             "title": "CouchDB Document ID",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_rev": {
             "title": "CouchDB Document Revision Number",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_revisions": {
@@ -52,6 +54,7 @@
                     "title": "Listener Callsign",
                     "description": "A callsign for this listener. Does not have to be an official amateur radio callsign.",
                     "type": "string",
+                    "minLength": 1,
                     "required": true
                 }
             }

--- a/couchdb/schemas/listener_telemetry.json
+++ b/couchdb/schemas/listener_telemetry.json
@@ -8,11 +8,13 @@
         "_id": {
             "title": "CouchDB Document ID",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_rev": {
             "title": "CouchDB Document Revision Number",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_revisions": {
@@ -52,6 +54,7 @@
                     "title": "Listener Callsign",
                     "description": "A callsign for this listener. Does not hae to be an official amateur radio callsign.",
                     "type": "string",
+                    "minLength": 1,
                     "required": true
                 },
                 "latitude": {

--- a/couchdb/schemas/payload_configuration.json
+++ b/couchdb/schemas/payload_configuration.json
@@ -8,11 +8,13 @@
         "_id": {
             "title": "CouchDB Document ID",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_rev": {
             "title": "CouchDB Document Revision Number",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_revisions": {
@@ -31,6 +33,7 @@
             "title": "Payload Name",
             "description": "The payload's name. Does not have to be its radio callsign.",
             "required": true,
+            "minLength": 1,
             "type": "string"
         },
         "time_created": {
@@ -59,12 +62,14 @@
                         "title": "Radio Mode",
                         "description": "The transmission mode in use, as a string, e.g. 'USB' or 'FM'.",
                         "type": "string",
+                        "minLength": 1,
                         "required": true
                     },
                     "modulation": {
                         "title": "Telemetry Modulation",
                         "description": "The form of modulation in use, can be anything. genpayload and dl-fldigi recognise 'RTTY', 'DominoEX' and 'Hellschreiber' (case sensitive).",
                         "type": "string",
+                        "minLength": 1,
                         "required": true
                     },
                     "shift": {
@@ -118,6 +123,7 @@
                         "title": "Telemetry Description",
                         "description": "A brief human readable description of this telemetry configuration, just used for UI.",
                         "type": "string",
+                        "minLength": 1,
                         "required": false
                     }
                 }
@@ -138,24 +144,28 @@
                         "title": "Sentence Protocol",
                         "description": "The protocol in use by this telemetry sentence, as a string, e.g., 'UKHAS'.",
                         "type": "string",
+                        "minLength": 1,
                         "required": true
                     },
                     "checksum": {
                         "title": "Sentence Checksum",
                         "description": "Where relevant, the checksum algorithm in use, as a string, e.g., 'crc16-ccitt'.",
                         "type": "string",
+                        "minLength": 1,
                         "required": false
                     },
                     "callsign": {
                         "title": "Payload Callsign",
                         "description": "The callsign of the payload. Used to look up what configuration should be used to parse incoming telemetry.",
                         "type": "string",
+                        "minLength": 1,
                         "required": true
                     },
                     "description": {
                         "title": "Sentence Description",
                         "description": "A brief human readable description of this sentence configuration, just used for UI.",
                         "type": "string",
+                        "minLength": 1,
                         "required": false
                     },
                     "fields": {
@@ -173,18 +183,21 @@
                                     "title": "Field Name",
                                     "description": "The name used to identify this field once parsed, as a string, e.g. 'altitude'.",
                                     "type": "string",
+                                    "minLength": 1,
                                     "required": true
                                 },
                                 "sensor": {
                                     "title": "Field Sensor",
                                     "description": "The sensor module used to parse this field, as a string, e.g. 'base.ascii_int'.",
                                     "type": "string",
+                                    "minLength": 1,
                                     "required": true
                                 },
                                 "format": {
                                     "title": "Field Format",
                                     "description": "When required by the sensor, the format to use parsing this field, e.g. 'dd.dddd'.",
                                     "type": "string",
+                                    "minLength": 1,
                                     "required": false
                                 }
                             }
@@ -219,24 +232,28 @@
                                             "title": "Filter function",
                                             "description": "For normal filters, this is the path of the function to execute, e.g. 'common.numeric_scale'.",
                                             "type": "string",
+                                            "minLength": 1,
                                             "required": false
                                         },
                                         "code": {
                                             "title": "Hotfix Code",
                                             "description": "For hotfix filters, this is the code to execute, specified as the body of a function with `data` as the parameter which should be modified and returned.",
                                             "type": "string",
+                                            "minLength": 1,
                                             "required": false
                                         },
                                         "signature": {
                                             "title": "Hotfix Signature",
                                             "description": "For hotfix filters, this is the signature to validate the code. See documentation for more details.",
                                             "type": "string",
+                                            "minLength": 1,
                                             "required": false
                                         },
                                         "certificate": {
                                             "title": "Hotfix Certificate",
                                             "description": "For hotfix filters, this is the certificate against which the signature should be checked. Given as a string certificate file name.",
                                             "type": "string",
+                                            "minLength": 1,
                                             "required": false
                                         }
                                     }
@@ -264,24 +281,28 @@
                                             "title": "Filter function",
                                             "description": "For normal filters, this is the path of the function to execute, e.g. 'common.numeric_scale'.",
                                             "type": "string",
+                                            "minLength": 1,
                                             "required": false
                                         },
                                         "code": {
                                             "title": "Hotfix Code",
                                             "description": "For hotfix filters, this is the code to execute, specified as the body of a function with `data` as the parameter which should be modified and returned.",
                                             "type": "string",
+                                            "minLength": 1,
                                             "required": false
                                         },
                                         "signature": {
                                             "title": "Hotfix Signature",
                                             "description": "For hotfix filters, this is the signature to validate the code. See documentation for more details.",
                                             "type": "string",
+                                            "minLength": 1,
                                             "required": false
                                         },
                                         "certificate": {
                                             "title": "Hotfix Certificate",
                                             "description": "For hotfix filters, this is the certificate against which the signature should be checked. Given as a string certificate file name.",
                                             "type": "string",
+                                            "minLength": 1,
                                             "required": false
                                         }
                                     }

--- a/couchdb/schemas/payload_telemetry.json
+++ b/couchdb/schemas/payload_telemetry.json
@@ -7,11 +7,13 @@
         "_id": {
             "title": "CouchDB Document ID",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_rev": {
             "title": "CouchDB Document Revision Number",
             "type": "string",
+            "minLength": 1,
             "required": false
         },
         "_revisions": {
@@ -50,6 +52,7 @@
                     "title": "Protocol",
                     "description": "The protocol (habitat parser module) used to parse this transmission. Inserted by the parser.",
                     "type": "string",
+                    "minLength": 1,
                     "required": false
                 },
                 "_parsed": {
@@ -70,6 +73,7 @@
                             "title": "Payload Configuration Document ID",
                             "description": "The document ID of the payload_configuration document used to parse this document.",
                             "required": true,
+                            "minLength": 1,
                             "type": "string"
                         },
                         "configuration_sentence_index": {
@@ -82,6 +86,7 @@
                             "title": "Flight ID",
                             "description": "The document ID of the flight associated with this telemetry, if it was parsed as part of a flight.",
                             "type": "string",
+                            "minLength": 1,
                             "required": false
                         }
                     }
@@ -90,6 +95,7 @@
                     "title": "Payload Callsign",
                     "description": "The callsign of the payload. Inserted by the parser.",
                     "type": "string",
+                    "minLength": 1,
                     "required": false
                 },
                 "sentence_id": {
@@ -165,12 +171,14 @@
                         "title": "Receiver Latest Telemtry",
                         "description": "A CouchDB document ID for this receiver's most recent listener_telemetry document.",
                         "type": "string",
+                        "minLength": 1,
                         "required": false
                     },
                     "latest_listener_information": {
                         "title": "Receiver Latest Info",
                         "description": "A CouchDB document ID for this receiver's most recent listener_information document.",
                         "type": "string",
+                        "minLength": 1,
                         "required": false
                     }
                 }


### PR DESCRIPTION
Started out as fix #297: callsigns must be non empty strings.

minLength requires the string be non empty if it is present; so you can have optional strings with minLength 1 on them.

I think this is desired behaviour (?)
Certainly having empty callsigns or empty document ids (in telem.receivers.latest_*, or _parsed.flight, etc.) is going to be a pain; I can't see any reason the other strings would be empty

I left one string: payload_telemetry.data._raw - this can be the empty string; legal base64 for an empty upload.
