### PR TITLE
Alternative sense method for ddmm.mmmm coordinates

### DIFF
--- a/habitat/sensors/stdtelem.py
+++ b/habitat/sensors/stdtelem.py
@@ -68,15 +68,14 @@ def coordinate(config, data):
     if left[-1] == "d" and right[-1] == "d":
         coord = float(data)
     elif left[0] == "d" and left[-1] == "m" and right[-1] == "m":
-        first, second = data.split(".")
-        degrees = float(first[:-2])
-        minutes = float(first[-2:] + "." + second)
+        val = float(data)
+        degrees = int(val / 100)
+        minutes = val - (degrees * 100)
         if minutes > 60.0:
             raise ValueError("Minutes component > 60.")
-        m_to_d = minutes / 60.0
-        degrees += math.copysign(m_to_d, degrees)
-        dp = len(second) + 3 # num digits in minutes + 1
-        coord = round(degrees, dp)
+        coord = degrees + (minutes / 60)
+        exponent = 3 + ( len(data.split('.')[1]) if data.find('.') > -1 else 0 )
+        coord = round(coord, exponent)
     else:
         raise ValueError("Invalid coordinate format")
 

--- a/habitat/tests/test_sensors/test_stdtelem.py
+++ b/habitat/tests/test_sensors/test_stdtelem.py
@@ -64,7 +64,11 @@ class TestStdtelem:
             ("dddmm.mmmm", "-3506.192", -35.1032),
             ("dddmm.mmmm", "-2431.5290", -24.5254833),
             ("dddmm.mmmm", "2431.529", 24.525483),
-            ("dddmm.mmmm", "-2431.0", -24.5167)
+            ("dddmm.mmmm", "-2431.0", -24.5167),
+            ("dddmm.mmmm", "-130.0", -1.5),
+            ("dddmm.mmmm", "30.0", 0.5),
+            ("dddmm.mmmm", "0.0", 0.0),
+            ("dddmm.mmmm", "0", 0.0)
         ]
         for i in coordinates:
             config = {"format": i[0], "miscellania": True, "asdf": 1234}
@@ -86,8 +90,7 @@ class TestStdtelem:
             ("dd.dddd", "+200.00"),
             ("ddmm.mm", "20000.0000"),
             ("ddmm.mm", "-20000.0000"),
-            ("ddmm.mm", "03599.1234"),
-            ("ddmm.mm", "-12")
+            ("ddmm.mm", "03599.1234")
         ]
         for i in invalid_coordinates:
             self.check_invalid_coordinate(i)


### PR DESCRIPTION
I've noticed that the coordinate routine for **ddmm.mmmm** format doesn't handle lack of padding, so I suggest the following changes.

Below are some test cases:

| Input (ddmm.mmmm) | Old method | New method |
| --: | --: | --: |
| 15530.001 | 155.500017 | 155.500017 |
| 5530.001 | 55.500017 | 55.500017 |
| 530.001 | 5.500017 | 5.500017 |
| 30.001 | could not convert string to float: | 0.500017 |
| 0.001 | could not convert string to float: | 1.7e-05 |
| -15530.001 | -155.500017 | -155.500017 |
| -5530.001 | -55.500017 | -55.500017 |
| -530.001 | -5.500017 | -5.500017 |
| -30.001 | could not convert string to float: - | -0.500017 |
| -0.001 | could not convert string to float: | -1.7e-05 |
| -15530.001 | -155.500017 | -155.500017 |
| -05530.001 | -55.500017 | -55.500017 |
| -00530.001 | -5.500017 | -5.500017 |
| -00030.001 | -0.500017 | -0.500017 |
| -00000.001 | -1.7e-05 | -1.7e-05 |
| 0 | need more than 1 value to unpack | 0.0 |
| 0.0 | could not convert string to float: | 0.0 |
| 161.000 | Minutes component > 60. | Minutes component > 60. |
