### PR TITLE
Radiosonde Telemetry Override

### DIFF
--- a/habitat.yml
+++ b/habitat.yml
@@ -1,4 +1,4 @@
-couch_uri: "localhost:5984"
+couch_uri: "http://localhost:5984"
 couch_db: habitat
 log_levels:
     stderr: DEBUG

--- a/habitat.yml
+++ b/habitat.yml
@@ -1,4 +1,4 @@
-couch_uri: "http://localhost:5984"
+couch_uri: "http://habitat.habhub.org"
 couch_db: habitat
 log_levels:
     stderr: DEBUG
@@ -26,3 +26,5 @@ loadables:
       class: "habitat.sensors.stdtelem"
     - name: "filters.common"
       class: "habitat.filters"
+radiosonde_override: "8c36ab528b16cb3adf00b7e07a228854"
+radiosonde_override_prefix: "RS_"

--- a/habitat.yml
+++ b/habitat.yml
@@ -1,4 +1,4 @@
-couch_uri: "http://habitat.habhub.org"
+couch_uri: "localhost:5984"
 couch_db: habitat
 log_levels:
     stderr: DEBUG

--- a/habitat/parser.py
+++ b/habitat/parser.py
@@ -65,7 +65,7 @@ class Parser(object):
 
         config = copy.deepcopy(config)
         parser_config = config["parser"]
-
+        
         self.loadable_manager = loadable_manager.LoadableManager(config)
         # loadable_manager used by ParserFiltering and ParserModules.
 
@@ -84,6 +84,20 @@ class Parser(object):
 
         self.couch_server = couchdbkit.Server(config["couch_uri"])
         self.db = self.couch_server[config["couch_db"]]
+
+        # Grab the radiosonde override config.
+        self.rs_prefix = "RS_" # Default radiosonde callsign identifier.
+        self.rs_config = None
+        try:
+            self.rs_prefix = config["radiosonde_override_prefix"]
+            _rs_config = self.db[config["radiosonde_override"]]
+            self.rs_config = {'payload_configuration': _rs_config, 'id': config["radiosonde_override"]}
+            logging.debug("Loaded radiosonde override payload doc (%s)" % config["radiosonde_override"])
+        except Exception as e:
+            logging.debug("Could not load radiosonde override payload doc - %s" % str(e))
+
+
+            
 
     @statsd.StatsdTimer.wrap('parser.time')
     def parse(self, doc, initial_config=None):
@@ -197,6 +211,7 @@ class Parser(object):
         Attempt to get a config doc given the callsign and maybe a provided
         config doc.
         """
+
         if config and not self._callsign_in_config(callsign, config):
             logger.debug("Callsign {c!r} not found in configuration doc"
                          .format(c=callsign))
@@ -208,7 +223,15 @@ class Parser(object):
                     .format(config["_id"]))
             return {"id": config["_id"], "payload_configuration": config}
 
-        config = self._find_config_doc(callsign)
+        if (self.rs_config != None) and callsign.startswith(self.rs_prefix):
+            logging.debug("Overriding payload doc lookup for radiosonde telemetry.")
+            config = copy.deepcopy(self.rs_config)
+            # Replace the callsign fields within the config to keep the downstream parsers happy.
+            config['payload_configuration']['name'] = callsign
+            config['payload_configuration']['sentences'][0]['callsign'] = callsign
+
+        else:
+            config = self._find_config_doc(callsign)
 
         if not config:
             logger.debug("No configuration doc for {callsign!r} found"


### PR DESCRIPTION
This PR adds in an option to bypass the parser's payload config lookup for a supplied callsign prefix. The use-case for this is to speed up parsing of the large amount of radiosonde telemetry now entering habitat.

Two entries have been added to habitat.yml. One provides the callsign prefix to use for filtering of radiosonde telemetry, the other provides the payload configuration document ID that will be used for telemetry parsing. If the provided document ID is invalid, the regular lookup system will be used instead.

This is currently running in production on kraken.habhub.org, and appears to have reduced parsing times considerably. 
Further testing will be conducted over the next few days during peak radiosonde traffic periods, to see if the latency issues remain.